### PR TITLE
feat(hooks): add useIntersectionObserver hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ npm install web-vitals
 | `useWebVitals` | Live Core Web Vitals (LCP, CLS, INP, FCP, TTFB) as React state | [Full docs](./docs/useWebVitals.md) |
 | `useDebouncedState` | Debounced `useState` with render-skip profiling counters | [Full docs](./docs/useDebouncedState.md) |
 | `useThrottledState` | Throttled `useState` with dropped-update profiling counters | [Full docs](./docs/useThrottledState.md) |
+| `useIntersectionObserver` | Lazy-loading visibility state plus first-visible and total-visible metrics | [Full docs](./docs/useIntersectionObserver.md) |
 
 See the [docs overview](./docs/index.md) for a complete reference.
 
@@ -50,7 +51,14 @@ See the [docs overview](./docs/index.md) for a complete reference.
 ## Quick start
 
 ```tsx
-import { useRenderTracker, usePerformanceMark, useWebVitals, useDebouncedState, useThrottledState } from 'react-perf-hooks';
+import {
+  useRenderTracker,
+  usePerformanceMark,
+  useWebVitals,
+  useDebouncedState,
+  useThrottledState,
+  useIntersectionObserver,
+} from 'react-perf-hooks';
 
 function App() {
   // Track re-renders and warn if a component renders more than 10 times
@@ -70,6 +78,9 @@ function App() {
   // Throttle high-frequency state while measuring discarded updates
   const [pointer, setPointer, pointerStats] = useThrottledState({ x: 0, y: 0 }, 120);
 
+  // Track when an element first becomes visible and for how long it stays visible
+  const { ref, isVisible, metrics } = useIntersectionObserver({ threshold: 0.25 });
+
   return <div>...</div>;
 }
 ```
@@ -77,6 +88,8 @@ function App() {
 `useDebouncedState` demo: [docs/demos/useDebouncedStateDemo.tsx](./docs/demos/useDebouncedStateDemo.tsx)
 
 `useThrottledState` demo: [docs/demos/useThrottledStateDemo.tsx](./docs/demos/useThrottledStateDemo.tsx)
+
+`useIntersectionObserver` demo: [docs/demos/useIntersectionObserverDemo.tsx](./docs/demos/useIntersectionObserverDemo.tsx)
 
 ---
 
@@ -99,6 +112,8 @@ import type {
   ThrottledStateStats,
   UseThrottledStateOptions,
   UseThrottledStateReturn,
+  IntersectionObserverMetrics,
+  UseIntersectionObserverReturn,
 } from 'react-perf-hooks';
 ```
 

--- a/docs/demos/useIntersectionObserverDemo.tsx
+++ b/docs/demos/useIntersectionObserverDemo.tsx
@@ -1,0 +1,64 @@
+import { useIntersectionObserver } from 'react-perf-hooks';
+
+export function UseIntersectionObserverDemo() {
+  const { ref, isVisible, metrics } = useIntersectionObserver<HTMLDivElement>({
+    threshold: 0.5,
+  });
+
+  return (
+    <section style={{ fontFamily: 'system-ui', maxWidth: 480 }}>
+      <p style={{ marginTop: 0 }}>
+        Scroll the panel until the highlighted card is at least 50% visible.
+      </p>
+
+      <div
+        style={{
+          height: 240,
+          overflowY: 'auto',
+          border: '1px solid #d4d4d8',
+          borderRadius: 12,
+          padding: 12,
+          background: 'linear-gradient(180deg, #fafaf9, #f4f4f5)',
+        }}
+      >
+        <div style={{ height: 180, display: 'grid', placeItems: 'center', color: '#71717a' }}>
+          Scroll down
+        </div>
+
+        <div
+          ref={ref}
+          style={{
+            minHeight: 140,
+            borderRadius: 12,
+            padding: 16,
+            background: isVisible ? 'linear-gradient(135deg, #dcfce7, #bbf7d0)' : 'linear-gradient(135deg, #e2e8f0, #cbd5e1)',
+            border: '1px solid rgba(15, 23, 42, 0.08)',
+            boxShadow: '0 10px 30px rgba(15, 23, 42, 0.08)',
+          }}
+        >
+          <strong>Observed card</strong>
+          <div style={{ marginTop: 8 }}>
+            {isVisible ? 'Visible now' : 'Below the visibility threshold'}
+          </div>
+        </div>
+
+        <div style={{ height: 220, display: 'grid', placeItems: 'center', color: '#71717a' }}>
+          Keep scrolling
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: 'grid',
+          gap: 4,
+          marginTop: 12,
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+        }}
+      >
+        <div>Visible: {String(isVisible)}</div>
+        <div>First visible at: {metrics.firstVisibleAt?.toFixed(1) ?? 'not yet'} ms</div>
+        <div>Total visible: {metrics.totalVisibleMs.toFixed(1)} ms</div>
+      </div>
+    </section>
+  );
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ A focused collection of React hooks for **performance monitoring, profiling, and
 | [useWebVitals](./useWebVitals.md) | Subscribe to all five Core Web Vitals as reactive React state |
 | [useDebouncedState](./useDebouncedState.md) | Debounced `useState` replacement with skipped-render profiling |
 | [useThrottledState](./useThrottledState.md) | Throttled `useState` replacement with dropped-update profiling |
+| [useIntersectionObserver](./useIntersectionObserver.md) | Observe element visibility and collect first-visible and total-visible metrics |
 
 ## Installation
 
@@ -35,6 +36,7 @@ import {
   useWebVitals,
   useDebouncedState,
   useThrottledState,
+  useIntersectionObserver,
 } from 'react-perf-hooks';
 ```
 
@@ -59,6 +61,8 @@ import type {
   ThrottledStateStats,
   UseThrottledStateOptions,
   UseThrottledStateReturn,
+  IntersectionObserverMetrics,
+  UseIntersectionObserverReturn,
 } from 'react-perf-hooks';
 ```
 

--- a/docs/useIntersectionObserver.md
+++ b/docs/useIntersectionObserver.md
@@ -1,0 +1,127 @@
+# useIntersectionObserver
+
+Observe an element with the browser `IntersectionObserver` API and capture two visibility metrics out of the box: when it first became visible and how long it has been visible in total.
+
+## Why use it?
+
+Lazy loading is only half the job. Once an element intersects the viewport, you often want to know:
+
+- When it first became visible relative to page load (`firstVisibleAt`)
+- How much cumulative time it spent visible (`totalVisibleMs`)
+- Whether it is visible right now (`isVisible`)
+
+This hook wraps those concerns into one SSR-safe API that works well for images, hero sections, ads, and engagement analytics.
+
+---
+
+## Import
+
+```ts
+import { useIntersectionObserver } from 'react-perf-hooks';
+```
+
+---
+
+## Signature
+
+```ts
+function useIntersectionObserver<T extends Element = Element>(
+  options?: IntersectionObserverInit
+): UseIntersectionObserverReturn<T>
+```
+
+---
+
+## Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `options` | `IntersectionObserverInit` | Standard observer options: `root`, `rootMargin`, and `threshold` |
+
+Notes:
+
+- `threshold` controls when `isVisible` flips to `true`
+- `root` defaults to the viewport
+- When rendered on the server, no observer is created
+
+---
+
+## Return value
+
+### `ref`
+
+Callback ref to attach to the target element you want to observe.
+
+### `isVisible`
+
+`true` when the latest observer entry satisfies the configured threshold, otherwise `false`.
+
+### `metrics`
+
+```ts
+interface IntersectionObserverMetrics {
+  firstVisibleAt: number | null;
+  totalVisibleMs: number;
+}
+```
+
+- `firstVisibleAt`: first time the target became visible, in ms since page load
+- `totalVisibleMs`: accumulated visible time across every visible session
+
+`totalVisibleMs` is flushed whenever the target leaves the visible state or the observer is cleaned up.
+
+---
+
+## Demo
+
+See: [`docs/demos/useIntersectionObserverDemo.tsx`](./demos/useIntersectionObserverDemo.tsx)
+
+```tsx
+import { useIntersectionObserver } from 'react-perf-hooks';
+
+function HeroImage() {
+  const { ref, isVisible, metrics } = useIntersectionObserver<HTMLImageElement>({
+    rootMargin: '200px 0px',
+    threshold: 0.25,
+  });
+
+  return (
+    <figure>
+      <img
+        ref={ref}
+        src={isVisible ? '/hero-full.jpg' : '/hero-placeholder.jpg'}
+        alt="Mountains at sunrise"
+      />
+      <figcaption>
+        First visible at: {metrics.firstVisibleAt?.toFixed(1) ?? 'not yet'} ms
+      </figcaption>
+      <figcaption>Total visible: {metrics.totalVisibleMs.toFixed(1)} ms</figcaption>
+    </figure>
+  );
+}
+```
+
+---
+
+## Notes
+
+- The hook uses `IntersectionObserverEntry.time` so timestamps align with the page-load-relative clock used by the Performance API.
+- If the target is visible when the observer is disconnected, the hook commits the in-progress visible duration during cleanup.
+- When `IntersectionObserver` is unavailable, the hook remains inert and returns the initial state.
+
+---
+
+## TypeScript interfaces
+
+```ts
+interface IntersectionObserverMetrics {
+  firstVisibleAt: number | null;
+  totalVisibleMs: number;
+}
+
+interface UseIntersectionObserverReturn<T extends Element = Element> {
+  ref: (node: T | null) => void;
+  isVisible: boolean;
+  metrics: IntersectionObserverMetrics;
+}
+```

--- a/src/hooks/useIntersectionObserver/index.ts
+++ b/src/hooks/useIntersectionObserver/index.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface IntersectionObserverMetrics {
+  /** Timestamp in ms since page load when the target first became visible */
+  firstVisibleAt: number | null;
+  /** Total accumulated visible time in ms across all visible sessions */
+  totalVisibleMs: number;
+}
+
+export interface UseIntersectionObserverReturn<T extends Element = Element> {
+  /** Callback ref to attach to the observed element */
+  ref: (node: T | null) => void;
+  /** Whether the target is currently visible within the observer root */
+  isVisible: boolean;
+  /** Built-in visibility timing metrics for analytics and performance reporting */
+  metrics: IntersectionObserverMetrics;
+}
+
+const INITIAL_METRICS: IntersectionObserverMetrics = {
+  firstVisibleAt: null,
+  totalVisibleMs: 0,
+};
+
+function clampThreshold(value: number): number {
+  return Math.min(Math.max(value, 0), 1);
+}
+
+function getVisibilityThreshold(threshold: IntersectionObserverInit['threshold']): number {
+  if (Array.isArray(threshold)) {
+    const thresholds = threshold.filter((value) => Number.isFinite(value)).map(clampThreshold);
+    return thresholds.length > 0 ? Math.min(...thresholds) : 0;
+  }
+
+  return typeof threshold === 'number' ? clampThreshold(threshold) : 0;
+}
+
+function getNow(): number {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+
+  return Date.now();
+}
+
+function isEntryVisible(entry: IntersectionObserverEntry, visibilityThreshold: number): boolean {
+  if (!entry.isIntersecting) return false;
+  if (visibilityThreshold <= 0) return true;
+  return entry.intersectionRatio >= visibilityThreshold;
+}
+
+/**
+ * Observes an element's visibility and captures timing metrics that matter for
+ * lazy loading, LCP analysis, and engagement reporting.
+ */
+export function useIntersectionObserver<T extends Element = Element>(
+  options: IntersectionObserverInit = {}
+): UseIntersectionObserverReturn<T> {
+  const { root = null, rootMargin, threshold } = options;
+  const [target, setTarget] = useState<T | null>(null);
+  const [isVisible, setIsVisible] = useState(false);
+  const [metrics, setMetrics] = useState<IntersectionObserverMetrics>(INITIAL_METRICS);
+  const isVisibleRef = useRef(false);
+  const visibleSinceRef = useRef<number | null>(null);
+  const visibilityThreshold = getVisibilityThreshold(threshold);
+
+  const ref = useCallback((node: T | null): void => {
+    setTarget(node);
+  }, []);
+
+  const commitVisibleDuration = useCallback((endTime: number): void => {
+    if (visibleSinceRef.current === null) return;
+
+    const duration = Math.max(0, endTime - visibleSinceRef.current);
+    visibleSinceRef.current = null;
+
+    if (duration === 0) return;
+
+    setMetrics((current) => ({
+      ...current,
+      totalVisibleMs: current.totalVisibleMs + duration,
+    }));
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined' || target === null) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[entries.length - 1];
+        if (!entry) return;
+
+        const nextVisible = isEntryVisible(entry, visibilityThreshold);
+        if (nextVisible === isVisibleRef.current) return;
+
+        isVisibleRef.current = nextVisible;
+
+        if (nextVisible) {
+          visibleSinceRef.current = entry.time;
+          setIsVisible(true);
+          setMetrics((current) => {
+            if (current.firstVisibleAt !== null) return current;
+
+            return {
+              ...current,
+              firstVisibleAt: entry.time,
+            };
+          });
+          return;
+        }
+
+        setIsVisible(false);
+        commitVisibleDuration(entry.time);
+      },
+      { root, rootMargin, threshold }
+    );
+
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+      setIsVisible(false);
+
+      if (isVisibleRef.current) {
+        isVisibleRef.current = false;
+        commitVisibleDuration(getNow());
+      }
+    };
+  }, [target, root, rootMargin, threshold, visibilityThreshold, commitVisibleDuration]);
+
+  return { ref, isVisible, metrics };
+}

--- a/src/hooks/useIntersectionObserver/useIntersectionObserver.test.tsx
+++ b/src/hooks/useIntersectionObserver/useIntersectionObserver.test.tsx
@@ -1,0 +1,204 @@
+import { act, renderHook } from '@testing-library/react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useIntersectionObserver } from './index';
+
+class MockIntersectionObserver implements IntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+
+  readonly root: Element | Document | null;
+  readonly rootMargin: string;
+  readonly thresholds: ReadonlyArray<number>;
+  private readonly callback: IntersectionObserverCallback;
+
+  readonly observe = vi.fn((_target: Element): void => undefined);
+  readonly unobserve = vi.fn((_target: Element): void => undefined);
+  readonly disconnect = vi.fn((): void => undefined);
+  readonly takeRecords = vi.fn((): IntersectionObserverEntry[] => []);
+
+  constructor(callback: IntersectionObserverCallback, options: IntersectionObserverInit = {}) {
+    this.callback = callback;
+    this.root = options.root ?? null;
+    this.rootMargin = options.rootMargin ?? '';
+    this.thresholds = Array.isArray(options.threshold) ? options.threshold : [options.threshold ?? 0];
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  trigger(entry: Partial<IntersectionObserverEntry>): void {
+    this.callback([entry as IntersectionObserverEntry], this);
+  }
+
+  static reset(): void {
+    MockIntersectionObserver.instances = [];
+  }
+}
+
+describe('useIntersectionObserver', () => {
+  beforeEach(() => {
+    MockIntersectionObserver.reset();
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns a ref callback, hidden state, and empty metrics initially', () => {
+    const { result } = renderHook(() => useIntersectionObserver());
+
+    expect(typeof result.current.ref).toBe('function');
+    expect(result.current.isVisible).toBe(false);
+    expect(result.current.metrics).toEqual({
+      firstVisibleAt: null,
+      totalVisibleMs: 0,
+    });
+  });
+
+  it('observes the target and records visibility metrics', () => {
+    const { result } = renderHook(() => useIntersectionObserver());
+    const target = document.createElement('div');
+
+    act(() => {
+      result.current.ref(target);
+    });
+
+    const observer = MockIntersectionObserver.instances[0]!;
+    expect(observer.observe).toHaveBeenCalledWith(target);
+
+    act(() => {
+      observer.trigger({
+        target,
+        isIntersecting: true,
+        intersectionRatio: 1,
+        time: 120,
+      });
+    });
+
+    expect(result.current.isVisible).toBe(true);
+    expect(result.current.metrics.firstVisibleAt).toBe(120);
+    expect(result.current.metrics.totalVisibleMs).toBe(0);
+
+    act(() => {
+      observer.trigger({
+        target,
+        isIntersecting: false,
+        intersectionRatio: 0,
+        time: 420,
+      });
+    });
+
+    expect(result.current.isVisible).toBe(false);
+    expect(result.current.metrics.totalVisibleMs).toBe(300);
+
+    act(() => {
+      observer.trigger({
+        target,
+        isIntersecting: true,
+        intersectionRatio: 1,
+        time: 600,
+      });
+      observer.trigger({
+        target,
+        isIntersecting: false,
+        intersectionRatio: 0,
+        time: 850,
+      });
+    });
+
+    expect(result.current.metrics.firstVisibleAt).toBe(120);
+    expect(result.current.metrics.totalVisibleMs).toBe(550);
+  });
+
+  it('respects threshold when determining visibility', () => {
+    const { result } = renderHook(() => useIntersectionObserver({ threshold: 0.5 }));
+    const target = document.createElement('div');
+
+    act(() => {
+      result.current.ref(target);
+    });
+
+    const observer = MockIntersectionObserver.instances[0]!;
+
+    act(() => {
+      observer.trigger({
+        target,
+        isIntersecting: true,
+        intersectionRatio: 0.25,
+        time: 80,
+      });
+    });
+
+    expect(result.current.isVisible).toBe(false);
+    expect(result.current.metrics.firstVisibleAt).toBeNull();
+
+    act(() => {
+      observer.trigger({
+        target,
+        isIntersecting: true,
+        intersectionRatio: 0.75,
+        time: 100,
+      });
+    });
+
+    expect(result.current.isVisible).toBe(true);
+    expect(result.current.metrics.firstVisibleAt).toBe(100);
+  });
+
+  it('commits ongoing visibility duration when the target is detached', () => {
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(260);
+    const { result } = renderHook(() => useIntersectionObserver());
+    const target = document.createElement('div');
+
+    act(() => {
+      result.current.ref(target);
+    });
+
+    const observer = MockIntersectionObserver.instances[0]!;
+
+    act(() => {
+      observer.trigger({
+        target,
+        isIntersecting: true,
+        intersectionRatio: 1,
+        time: 100,
+      });
+    });
+
+    act(() => {
+      result.current.ref(null);
+    });
+
+    expect(observer.disconnect).toHaveBeenCalledTimes(1);
+    expect(nowSpy).toHaveBeenCalled();
+    expect(result.current.isVisible).toBe(false);
+    expect(result.current.metrics.totalVisibleMs).toBe(160);
+  });
+
+  it('does not create an observer when IntersectionObserver is unavailable', () => {
+    vi.stubGlobal('IntersectionObserver', undefined);
+    const { result } = renderHook(() => useIntersectionObserver());
+    const target = document.createElement('div');
+
+    act(() => {
+      result.current.ref(target);
+    });
+
+    expect(MockIntersectionObserver.instances).toHaveLength(0);
+    expect(result.current.isVisible).toBe(false);
+    expect(result.current.metrics.firstVisibleAt).toBeNull();
+  });
+
+  it('is safe to render during SSR', () => {
+    function TestComponent() {
+      const { isVisible, metrics } = useIntersectionObserver();
+      return (
+        <div data-visible={String(isVisible)}>
+          {metrics.firstVisibleAt ?? 'never'}:{metrics.totalVisibleMs}
+        </div>
+      );
+    }
+
+    expect(() => renderToString(<TestComponent />)).not.toThrow();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,6 @@ export type { DebouncedStateStats, UseDebouncedStateReturn } from './hooks/useDe
 
 export { useThrottledState } from './hooks/useThrottledState';
 export type { ThrottledStateStats, UseThrottledStateOptions, UseThrottledStateReturn } from './hooks/useThrottledState';
+
+export { useIntersectionObserver } from './hooks/useIntersectionObserver';
+export type { IntersectionObserverMetrics, UseIntersectionObserverReturn } from './hooks/useIntersectionObserver';


### PR DESCRIPTION
https://github.com/valyefimov/react-perf-hooks/issues/5

Adds a new hook `useIntersectionObserver` which provides visibility state and metrics for observed elements. This hook leverages the `IntersectionObserver` API to track when an element first becomes visible and for how long it remains visible. It's useful for implementing lazy loading, performance monitoring, and engagement analytics. The hook also includes a demo component and extensive documentation.