### PR TITLE
feat(hooks): add useMemoProfiling hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ npm install web-vitals
 | `useRenderTracker` | Find components that re-render too often and why | [Full docs](./docs/useRenderTracker.md) |
 | `usePerformanceMark` | Precise timing of any code path via the Performance API | [Full docs](./docs/usePerformanceMark.md) |
 | `useComponentLifecycle` | Track mount/unmount timings and live component lifetime | [Full docs](./docs/useComponentLifecycle.md) |
+| `useMemoProfiling` | Profile `useMemo` cache hits/misses and recomputation costs | [Full docs](./docs/useMemoProfiling.md) |
 | `useWebVitals` | Live Core Web Vitals (LCP, CLS, INP, FCP, TTFB) as React state | [Full docs](./docs/useWebVitals.md) |
 | `useDebouncedState` | Debounced `useState` with render-skip profiling counters | [Full docs](./docs/useDebouncedState.md) |
 | `useThrottledState` | Throttled `useState` with dropped-update profiling counters | [Full docs](./docs/useThrottledState.md) |
@@ -56,6 +57,7 @@ import {
   useRenderTracker,
   usePerformanceMark,
   useComponentLifecycle,
+  useMemoProfiling,
   useWebVitals,
   useDebouncedState,
   useThrottledState,
@@ -71,6 +73,9 @@ function App() {
 
   // Track mount time and current lifetime of a component
   const { mountedAt, aliveMs } = useComponentLifecycle('App');
+
+  // Profile whether this memoized computation is mostly cache HITs or MISSes
+  const filteredUsers = useMemoProfiling(() => users.filter((u) => u.active), [users], 'ActiveUsers');
 
   // Subscribe to Core Web Vitals and report to analytics
   const vitals = useWebVitals({
@@ -96,6 +101,8 @@ function App() {
 
 `useComponentLifecycle` demo: [docs/demos/useComponentLifecycleDemo.tsx](./docs/demos/useComponentLifecycleDemo.tsx)
 
+`useMemoProfiling` demo: [docs/demos/useMemoProfilingDemo.tsx](./docs/demos/useMemoProfilingDemo.tsx)
+
 `useIntersectionObserver` demo: [docs/demos/useIntersectionObserverDemo.tsx](./docs/demos/useIntersectionObserverDemo.tsx)
 
 ---
@@ -111,6 +118,7 @@ import type {
   PerformanceMeasureResult,
   UsePerformanceMarkReturn,
   ComponentLifecycleInfo,
+  MemoProfilingStats,
   WebVitalMetric,
   WebVitalsState,
   UseWebVitalsOptions,

--- a/docs/demos/useMemoProfilingDemo.tsx
+++ b/docs/demos/useMemoProfilingDemo.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { getStats, useMemoProfiling } from 'react-perf-hooks';
+
+const items = [
+  'React',
+  'Vue',
+  'Svelte',
+  'Angular',
+  'Solid',
+  'Qwik',
+  'Preact',
+  'Lit',
+  'Remix',
+  'Next.js',
+  'Nuxt',
+  'Astro',
+];
+
+export function UseMemoProfilingDemo() {
+  const [query, setQuery] = useState('r');
+  const [uiTick, setUiTick] = useState(0);
+  const label = 'FrameworkFilter';
+
+  const filteredItems = useMemoProfiling(
+    () => {
+      const lowered = query.trim().toLowerCase();
+      return items.filter((item) => item.toLowerCase().includes(lowered));
+    },
+    [query],
+    label
+  );
+
+  const stats = getStats(label);
+
+  return (
+    <section style={{ fontFamily: 'system-ui', maxWidth: 520 }}>
+      <label htmlFor="memo-query" style={{ display: 'block', marginBottom: 8, fontWeight: 600 }}>
+        Filter frameworks
+      </label>
+
+      <input
+        id="memo-query"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder="Type a query..."
+        style={{ width: '100%', padding: '8px 10px', marginBottom: 10 }}
+      />
+
+      <button type="button" onClick={() => setUiTick((value) => value + 1)} style={{ marginBottom: 12 }}>
+        Force unrelated re-render ({uiTick})
+      </button>
+
+      <div style={{ display: 'grid', gap: 4, marginBottom: 12, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace' }}>
+        <div>Hits: {stats.hits}</div>
+        <div>Misses: {stats.misses}</div>
+        <div>Avg miss cost: {stats.averageRecomputeMs.toFixed(2)} ms</div>
+      </div>
+
+      <ul style={{ margin: 0, paddingLeft: 20 }}>
+        {filteredItems.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ A focused collection of React hooks for **performance monitoring, profiling, and
 | [useRenderTracker](./useRenderTracker.md) | Count re-renders, detect which props changed, warn when threshold is exceeded |
 | [usePerformanceMark](./usePerformanceMark.md) | Measure arbitrary code paths using the browser Performance API |
 | [useComponentLifecycle](./useComponentLifecycle.md) | Track mount and unmount times, plus live lifetime since mount |
+| [useMemoProfiling](./useMemoProfiling.md) | Profile `useMemo` cache effectiveness with HIT/MISS stats |
 | [useWebVitals](./useWebVitals.md) | Subscribe to all five Core Web Vitals as reactive React state |
 | [useDebouncedState](./useDebouncedState.md) | Debounced `useState` replacement with skipped-render profiling |
 | [useThrottledState](./useThrottledState.md) | Throttled `useState` replacement with dropped-update profiling |
@@ -35,6 +36,7 @@ import {
   useRenderTracker,
   usePerformanceMark,
   useComponentLifecycle,
+  useMemoProfiling,
   useWebVitals,
   useDebouncedState,
   useThrottledState,
@@ -55,6 +57,7 @@ import type {
   PerformanceMeasureResult,
   UsePerformanceMarkReturn,
   ComponentLifecycleInfo,
+  MemoProfilingStats,
   WebVitalMetric,
   WebVitalsState,
   UseWebVitalsOptions,

--- a/docs/useMemoProfiling.md
+++ b/docs/useMemoProfiling.md
@@ -1,0 +1,90 @@
+# useMemoProfiling
+
+`useMemo` wrapper that reports cache HIT/MISS effectiveness in development and tracks stats per label.
+
+## Why use it?
+
+`useMemo` is often added without verification. This hook makes it measurable:
+
+- Shows whether memoization is actually producing cache hits
+- Logs recomputation cost when cache misses happen
+- Exposes programmatic stats with `getStats(label)`
+
+In production it behaves as a plain `useMemo` with no profiling output.
+
+## Import
+
+```ts
+import { getStats, useMemoProfiling } from 'react-perf-hooks';
+```
+
+## Signature
+
+```ts
+function useMemoProfiling<T>(
+  factory: () => T,
+  deps: DependencyList,
+  label?: string
+): T
+
+function getStats(label?: string): MemoProfilingStats
+```
+
+## Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `factory` | `() => T` | Same as `useMemo` factory |
+| `deps` | `DependencyList` | Same dependency list semantics as `useMemo` |
+| `label` | `string` | Optional grouping key for logs and stats (default: `"default"`) |
+
+## Return value
+
+Same as `useMemo`: returns the memoized value of type `T`.
+
+## Console output (development only)
+
+```txt
+[useMemoProfiling:SearchFilter] MISS (recomputed in 2.41ms)
+[useMemoProfiling:SearchFilter] HIT
+```
+
+## `getStats(label)` result
+
+```ts
+interface MemoProfilingStats {
+  label: string;
+  hits: number;
+  misses: number;
+  totalRecomputeMs: number;
+  averageRecomputeMs: number;
+}
+```
+
+## Example
+
+```tsx
+import { getStats, useMemoProfiling } from 'react-perf-hooks';
+
+function ProductTable({ products, query }: Props) {
+  const filtered = useMemoProfiling(
+    () => products.filter((p) => p.name.toLowerCase().includes(query.toLowerCase())),
+    [products, query],
+    'ProductTable:filter'
+  );
+
+  const stats = getStats('ProductTable:filter');
+
+  return (
+    <section>
+      <p>Hits: {stats.hits} | Misses: {stats.misses}</p>
+      <ul>{filtered.map((p) => <li key={p.id}>{p.name}</li>)}</ul>
+    </section>
+  );
+}
+```
+
+## Notes
+
+- First render is always a cache MISS because the value is computed for the first time.
+- In production (`NODE_ENV=production`), logging and stats collection are disabled.

--- a/src/hooks/useMemoProfiling/index.ts
+++ b/src/hooks/useMemoProfiling/index.ts
@@ -1,0 +1,121 @@
+import { type DependencyList, useMemo } from 'react';
+
+export interface MemoProfilingStats {
+  /** Label associated with the profiled memoized value */
+  label: string;
+  /** Number of renders that reused the cached value */
+  hits: number;
+  /** Number of renders that recomputed the value */
+  misses: number;
+  /** Total milliseconds spent recomputing across all misses */
+  totalRecomputeMs: number;
+  /** Average milliseconds per miss */
+  averageRecomputeMs: number;
+}
+
+interface MutableMemoProfilingStats {
+  hits: number;
+  misses: number;
+  totalRecomputeMs: number;
+}
+
+const DEFAULT_LABEL = 'default';
+const statsStore = new Map<string, MutableMemoProfilingStats>();
+
+const isProfilingEnabled = (): boolean => process.env.NODE_ENV !== 'production';
+
+const getNow = (): number => {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+
+  return Date.now();
+};
+
+const normalizeLabel = (label?: string): string => {
+  const trimmed = label?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : DEFAULT_LABEL;
+};
+
+const toPublicStats = (label: string, mutableStats?: MutableMemoProfilingStats): MemoProfilingStats => {
+  const hits = mutableStats?.hits ?? 0;
+  const misses = mutableStats?.misses ?? 0;
+  const totalRecomputeMs = mutableStats?.totalRecomputeMs ?? 0;
+
+  return {
+    label,
+    hits,
+    misses,
+    totalRecomputeMs,
+    averageRecomputeMs: misses > 0 ? totalRecomputeMs / misses : 0,
+  };
+};
+
+const getOrCreateStats = (label: string): MutableMemoProfilingStats => {
+  const existing = statsStore.get(label);
+  if (existing) return existing;
+
+  const created: MutableMemoProfilingStats = {
+    hits: 0,
+    misses: 0,
+    totalRecomputeMs: 0,
+  };
+
+  statsStore.set(label, created);
+  return created;
+};
+
+/**
+ * Returns cache hit/miss stats for a specific memo label.
+ * In production this always returns zeroed stats.
+ */
+export function getStats(label?: string): MemoProfilingStats {
+  const resolvedLabel = normalizeLabel(label);
+
+  if (!isProfilingEnabled()) {
+    return toPublicStats(resolvedLabel);
+  }
+
+  return toPublicStats(resolvedLabel, statsStore.get(resolvedLabel));
+}
+
+/**
+ * `useMemo` wrapper that reports cache HIT/MISS behavior in development.
+ * In production it behaves like a plain `useMemo` with zero profiling overhead.
+ */
+export function useMemoProfiling<T>(factory: () => T, deps: DependencyList, label?: string): T {
+  const resolvedLabel = normalizeLabel(label);
+  const profilingEnabled = isProfilingEnabled();
+
+  let cacheHit = true;
+  let recomputeMs = 0;
+
+  const value = useMemo(() => {
+    if (!profilingEnabled) {
+      return factory();
+    }
+
+    cacheHit = false;
+    const start = getNow();
+    const computed = factory();
+    recomputeMs = Math.max(0, getNow() - start);
+    return computed;
+  }, deps);
+
+  if (!profilingEnabled) {
+    return value;
+  }
+
+  const stats = getOrCreateStats(resolvedLabel);
+
+  if (cacheHit) {
+    stats.hits += 1;
+    console.log(`[useMemoProfiling:${resolvedLabel}] HIT`);
+  } else {
+    stats.misses += 1;
+    stats.totalRecomputeMs += recomputeMs;
+    console.log(`[useMemoProfiling:${resolvedLabel}] MISS (recomputed in ${recomputeMs.toFixed(2)}ms)`);
+  }
+
+  return value;
+}

--- a/src/hooks/useMemoProfiling/index.ts
+++ b/src/hooks/useMemoProfiling/index.ts
@@ -1,4 +1,4 @@
-import { type DependencyList, useMemo } from 'react';
+import { type DependencyList, useEffect, useMemo, useRef } from 'react';
 
 export interface MemoProfilingStats {
   /** Label associated with the profiled memoized value */
@@ -17,6 +17,11 @@ interface MutableMemoProfilingStats {
   hits: number;
   misses: number;
   totalRecomputeMs: number;
+}
+
+interface MemoSnapshot<T> {
+  value: T;
+  recomputeMs: number;
 }
 
 const DEFAULT_LABEL = 'default';
@@ -87,35 +92,48 @@ export function useMemoProfiling<T>(factory: () => T, deps: DependencyList, labe
   const resolvedLabel = normalizeLabel(label);
   const profilingEnabled = isProfilingEnabled();
 
-  let cacheHit = true;
-  let recomputeMs = 0;
-
-  const value = useMemo(() => {
+  // Intentionally mirror useMemo semantics by trusting caller-provided deps.
+  /* eslint-disable react-hooks/use-memo, react-hooks/exhaustive-deps */
+  const currentSnapshot = useMemo<MemoSnapshot<T>>(() => {
     if (!profilingEnabled) {
-      return factory();
+      return {
+        value: factory(),
+        recomputeMs: 0,
+      };
     }
 
-    cacheHit = false;
     const start = getNow();
-    const computed = factory();
-    recomputeMs = Math.max(0, getNow() - start);
-    return computed;
+    const value = factory();
+
+    return {
+      value,
+      recomputeMs: Math.max(0, getNow() - start),
+    };
   }, deps);
+  /* eslint-enable react-hooks/use-memo, react-hooks/exhaustive-deps */
 
-  if (!profilingEnabled) {
-    return value;
-  }
+  const previousSnapshotRef = useRef<MemoSnapshot<T> | null>(null);
 
-  const stats = getOrCreateStats(resolvedLabel);
+  useEffect(() => {
+    if (!profilingEnabled) return;
 
-  if (cacheHit) {
-    stats.hits += 1;
-    console.log(`[useMemoProfiling:${resolvedLabel}] HIT`);
-  } else {
-    stats.misses += 1;
-    stats.totalRecomputeMs += recomputeMs;
-    console.log(`[useMemoProfiling:${resolvedLabel}] MISS (recomputed in ${recomputeMs.toFixed(2)}ms)`);
-  }
+    const previousSnapshot = previousSnapshotRef.current;
+    const isHit = previousSnapshot === currentSnapshot && previousSnapshot !== null;
+    const stats = getOrCreateStats(resolvedLabel);
 
-  return value;
+    if (isHit) {
+      stats.hits += 1;
+      console.log(`[useMemoProfiling:${resolvedLabel}] HIT`);
+    } else {
+      stats.misses += 1;
+      stats.totalRecomputeMs += currentSnapshot.recomputeMs;
+      console.log(
+        `[useMemoProfiling:${resolvedLabel}] MISS (recomputed in ${currentSnapshot.recomputeMs.toFixed(2)}ms)`
+      );
+    }
+
+    previousSnapshotRef.current = currentSnapshot;
+  });
+
+  return currentSnapshot.value;
 }

--- a/src/hooks/useMemoProfiling/useMemoProfiling.test.tsx
+++ b/src/hooks/useMemoProfiling/useMemoProfiling.test.tsx
@@ -1,0 +1,118 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getStats, useMemoProfiling } from './index';
+
+describe('useMemoProfiling', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  let labelCounter = 0;
+
+  const nextLabel = (): string => {
+    const label = `useMemoProfiling-test-${labelCounter}`;
+    labelCounter += 1;
+    return label;
+  };
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('returns memoized value and recomputes only when deps change', () => {
+    const label = nextLabel();
+    let multiplier = 2;
+    const factory = vi.fn(() => multiplier * 10);
+
+    const { result, rerender } = renderHook(() => useMemoProfiling(factory, [multiplier], label));
+
+    expect(result.current).toBe(20);
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    rerender();
+    expect(result.current).toBe(20);
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    multiplier = 3;
+    rerender();
+    expect(result.current).toBe(30);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs MISS with recomputation time and HIT when cached value is reused', () => {
+    const label = nextLabel();
+    let dep = 1;
+
+    const { rerender } = renderHook(() => useMemoProfiling(() => dep * 2, [dep], label));
+
+    rerender(); // unchanged dep -> HIT
+    dep = 2;
+    rerender(); // changed dep -> MISS
+
+    const calls = vi.mocked(console.log).mock.calls.map((entry) => entry[0]);
+
+    expect(calls).toHaveLength(3);
+    expect(calls[0]).toMatch(new RegExp(`^\\[useMemoProfiling:${label}\\] MISS \\(recomputed in \\d+\\.\\d{2}ms\\)$`));
+    expect(calls[1]).toBe(`[useMemoProfiling:${label}] HIT`);
+    expect(calls[2]).toMatch(new RegExp(`^\\[useMemoProfiling:${label}\\] MISS \\(recomputed in \\d+\\.\\d{2}ms\\)$`));
+  });
+
+  it('exposes accumulated stats via getStats(label)', () => {
+    const label = nextLabel();
+    let dep = 'a';
+
+    const { rerender } = renderHook(() => useMemoProfiling(() => dep.toUpperCase(), [dep], label));
+
+    rerender(); // HIT
+    dep = 'b';
+    rerender(); // MISS
+    rerender(); // HIT
+
+    const stats = getStats(label);
+
+    expect(stats.label).toBe(label);
+    expect(stats.hits).toBe(2);
+    expect(stats.misses).toBe(2);
+    expect(stats.totalRecomputeMs).toBeGreaterThanOrEqual(0);
+    expect(stats.averageRecomputeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns zeroed stats for an unseen label', () => {
+    const label = nextLabel();
+    const stats = getStats(label);
+
+    expect(stats.label).toBe(label);
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
+    expect(stats.totalRecomputeMs).toBe(0);
+    expect(stats.averageRecomputeMs).toBe(0);
+  });
+
+  it('is a no-op in production (no logs, no profiling stats)', () => {
+    process.env.NODE_ENV = 'production';
+
+    const label = nextLabel();
+    let dep = 5;
+    const factory = vi.fn(() => dep + 1);
+
+    const { result, rerender } = renderHook(() => useMemoProfiling(factory, [dep], label));
+    expect(result.current).toBe(6);
+
+    rerender(); // unchanged dep -> cached value
+    dep = 6;
+    rerender(); // changed dep -> recompute
+    expect(result.current).toBe(7);
+
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(console.log).not.toHaveBeenCalled();
+
+    const stats = getStats(label);
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
+    expect(stats.totalRecomputeMs).toBe(0);
+    expect(stats.averageRecomputeMs).toBe(0);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,9 @@ export type { PerformanceMeasureResult, UsePerformanceMarkReturn } from './hooks
 export { useComponentLifecycle } from './hooks/useComponentLifecycle';
 export type { ComponentLifecycleInfo } from './hooks/useComponentLifecycle';
 
+export { getStats, useMemoProfiling } from './hooks/useMemoProfiling';
+export type { MemoProfilingStats } from './hooks/useMemoProfiling';
+
 export { useWebVitals } from './hooks/useWebVitals';
 export type { WebVitalMetric, WebVitalsState, UseWebVitalsOptions, VitalRating } from './hooks/useWebVitals';
 


### PR DESCRIPTION
This hook wraps `useMemo` and logs cache hit/miss behavior in development. It also exposes programmatic access to profiling statistics.