### PR TITLE
feat(render-budget): add useRenderBudget hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npm install web-vitals
 | Hook | What it solves | Docs |
 |------|---------------|------|
 | `useRenderTracker` | Find components that re-render too often and why | [Full docs](./docs/useRenderTracker.md) |
+| `useRenderBudget` | Warn when a single render commit exceeds a time budget (default: 16ms) | [Full docs](./docs/useRenderBudget.md) |
 | `usePerformanceMark` | Precise timing of any code path via the Performance API | [Full docs](./docs/usePerformanceMark.md) |
 | `useComponentLifecycle` | Track mount/unmount timings and live component lifetime | [Full docs](./docs/useComponentLifecycle.md) |
 | `useWebVitals` | Live Core Web Vitals (LCP, CLS, INP, FCP, TTFB) as React state | [Full docs](./docs/useWebVitals.md) |
@@ -54,6 +55,7 @@ See the [docs overview](./docs/index.md) for a complete reference.
 ```tsx
 import {
   useRenderTracker,
+  useRenderBudget,
   usePerformanceMark,
   useComponentLifecycle,
   useWebVitals,
@@ -65,6 +67,9 @@ import {
 function App() {
   // Track re-renders and warn if a component renders more than 10 times
   const { count } = useRenderTracker({ userId }, { name: 'App', warnAt: 10 });
+
+  // Warn when a render exceeds one frame budget (16ms by default)
+  useRenderBudget(16, 'App');
 
   // Measure fetch duration with the Performance API
   const { mark, measure } = usePerformanceMark('App');
@@ -98,6 +103,8 @@ function App() {
 
 `useIntersectionObserver` demo: [docs/demos/useIntersectionObserverDemo.tsx](./docs/demos/useIntersectionObserverDemo.tsx)
 
+`useRenderBudget` demo: [docs/demos/useRenderBudgetDemo.tsx](./docs/demos/useRenderBudgetDemo.tsx)
+
 ---
 
 ## TypeScript
@@ -108,6 +115,7 @@ All hooks ship with full type declarations. No `@types/*` packages needed.
 import type {
   RenderInfo,
   UseRenderTrackerOptions,
+  UseRenderBudgetOptions,
   PerformanceMeasureResult,
   UsePerformanceMarkReturn,
   ComponentLifecycleInfo,

--- a/docs/demos/useRenderBudgetDemo.tsx
+++ b/docs/demos/useRenderBudgetDemo.tsx
@@ -1,0 +1,62 @@
+import { useMemo, useState } from 'react';
+import { useRenderBudget } from 'react-perf-hooks';
+
+function SlowPreview({ size, budget }: { size: number; budget: number }) {
+  useRenderBudget(budget, 'SlowPreview');
+
+  const score = useMemo(() => {
+    let total = 0;
+
+    for (let i = 0; i < size * 12000; i += 1) {
+      total += Math.sqrt((i % 1000) + 1);
+    }
+
+    return Math.round(total);
+  }, [size]);
+
+  return (
+    <div
+      style={{
+        border: '1px solid #d4d4d8',
+        borderRadius: 12,
+        padding: 16,
+        background: 'linear-gradient(135deg, #fef3c7, #fde68a)',
+      }}
+    >
+      <strong>SlowPreview render payload</strong>
+      <div style={{ marginTop: 8 }}>Input size: {size}</div>
+      <div>Computed score: {score.toLocaleString()}</div>
+    </div>
+  );
+}
+
+export function UseRenderBudgetDemo() {
+  const [size, setSize] = useState(70);
+  const [budget, setBudget] = useState(16);
+
+  return (
+    <section style={{ fontFamily: 'system-ui', maxWidth: 520 }}>
+      <p style={{ marginTop: 0 }}>
+        Move either slider to trigger re-renders. Open the console to see warnings when render time exceeds budget.
+      </p>
+
+      <label style={{ display: 'grid', gap: 6, marginBottom: 12 }}>
+        <span>Workload size: {size}</span>
+        <input type="range" min={20} max={140} value={size} onChange={(event) => setSize(Number(event.target.value))} />
+      </label>
+
+      <label style={{ display: 'grid', gap: 6, marginBottom: 12 }}>
+        <span>Budget (ms): {budget}</span>
+        <input
+          type="range"
+          min={4}
+          max={40}
+          value={budget}
+          onChange={(event) => setBudget(Number(event.target.value))}
+        />
+      </label>
+
+      <SlowPreview size={size} budget={budget} />
+    </section>
+  );
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ A focused collection of React hooks for **performance monitoring, profiling, and
 | Hook | Purpose |
 |------|---------|
 | [useRenderTracker](./useRenderTracker.md) | Count re-renders, detect which props changed, warn when threshold is exceeded |
+| [useRenderBudget](./useRenderBudget.md) | Measure render-to-commit time and warn when a component exceeds a frame budget |
 | [usePerformanceMark](./usePerformanceMark.md) | Measure arbitrary code paths using the browser Performance API |
 | [useComponentLifecycle](./useComponentLifecycle.md) | Track mount and unmount times, plus live lifetime since mount |
 | [useWebVitals](./useWebVitals.md) | Subscribe to all five Core Web Vitals as reactive React state |
@@ -33,6 +34,7 @@ npm install web-vitals
 ```tsx
 import {
   useRenderTracker,
+  useRenderBudget,
   usePerformanceMark,
   useComponentLifecycle,
   useWebVitals,
@@ -52,6 +54,7 @@ The package ships with full type declarations. No `@types/*` needed.
 import type {
   RenderInfo,
   UseRenderTrackerOptions,
+  UseRenderBudgetOptions,
   PerformanceMeasureResult,
   UsePerformanceMarkReturn,
   ComponentLifecycleInfo,

--- a/docs/useRenderBudget.md
+++ b/docs/useRenderBudget.md
@@ -1,0 +1,109 @@
+# useRenderBudget
+
+Measures the time from **render start to commit** and warns when a component exceeds a render-time budget.
+
+Default budget is **16ms** (one 60fps frame).
+
+## Why use it?
+
+Render performance regressions often slip in gradually. `useRenderBudget` gives immediate feedback in development so slow components are caught close to where they were introduced.
+
+- Measures each commit with `performance.now()`
+- Warns with component name, actual time, and budget
+- Supports strict mode to throw instead of warn
+- Automatically disabled in production by default
+
+---
+
+## Import
+
+```ts
+import { useRenderBudget } from 'react-perf-hooks';
+```
+
+---
+
+## Signature
+
+```ts
+function useRenderBudget(
+  budgetMs?: number,
+  componentName?: string,
+  options?: UseRenderBudgetOptions
+): void
+```
+
+---
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `budgetMs` | `number` | `16` | Max allowed render-to-commit duration in milliseconds |
+| `componentName` | `string` | `"Component"` | Label included in warnings/errors |
+| `options.enabled` | `boolean` | `true` in dev / `false` in prod | Set to `true` to force-enable in production debugging |
+| `options.strict` | `boolean` | `false` | Throw an error instead of calling `console.warn` |
+
+---
+
+## Console output
+
+When a commit exceeds budget:
+
+```text
+⚠️ [useRenderBudget] MyComponent exceeded budget: 34ms (budget: 16ms)
+```
+
+---
+
+## Examples
+
+### Basic usage
+
+```tsx
+import { useRenderBudget } from 'react-perf-hooks';
+
+function SearchResults({ items }: { items: string[] }) {
+  useRenderBudget(16, 'SearchResults');
+  return <ul>{items.map((item) => <li key={item}>{item}</li>)}</ul>;
+}
+```
+
+### Strict mode (throw)
+
+```tsx
+function ExpensiveChart(props: Props) {
+  useRenderBudget(12, 'ExpensiveChart', { strict: true });
+  return <canvas />;
+}
+```
+
+### Force-enable in production debug builds
+
+```tsx
+const debugPerf = process.env.NEXT_PUBLIC_PERF_DEBUG === 'true';
+
+function App() {
+  useRenderBudget(16, 'App', { enabled: debugPerf });
+  return <main>...</main>;
+}
+```
+
+---
+
+## Notes
+
+- Measurement happens on every commit while enabled.
+- In React Strict Mode (development), components can render/commit more than once for intentional checks.
+- Passing an invalid `budgetMs` (e.g. `0`, negative, `NaN`) falls back to `16ms`.
+
+---
+
+## TypeScript
+
+```ts
+interface UseRenderBudgetOptions {
+  enabled?: boolean;
+  strict?: boolean;
+}
+```

--- a/src/hooks/useRenderBudget/index.ts
+++ b/src/hooks/useRenderBudget/index.ts
@@ -1,0 +1,61 @@
+import { useEffect, useLayoutEffect, useRef } from 'react';
+
+export interface UseRenderBudgetOptions {
+  /**
+   * Enable tracking. Defaults to true in development, false in production.
+   * Pass `true` to force-enable in production for targeted debugging.
+   */
+  enabled?: boolean;
+  /**
+   * Throw an error instead of logging a warning when the budget is exceeded.
+   */
+  strict?: boolean;
+}
+
+const DEFAULT_BUDGET_MS = 16;
+const DEFAULT_COMPONENT_NAME = 'Component';
+
+const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+function formatMs(value: number): string {
+  return Number(value.toFixed(2)).toString();
+}
+
+/**
+ * Measures render start -> commit duration and warns when a component exceeds
+ * a configurable frame budget.
+ */
+export function useRenderBudget(
+  budgetMs = DEFAULT_BUDGET_MS,
+  componentName = DEFAULT_COMPONENT_NAME,
+  options: UseRenderBudgetOptions = {}
+): void {
+  const { strict = false, enabled = process.env.NODE_ENV !== 'production' } = options;
+
+  const renderStartRef = useRef(0);
+
+  const normalizedBudget = Number.isFinite(budgetMs) && budgetMs > 0 ? budgetMs : DEFAULT_BUDGET_MS;
+  const normalizedName = componentName.trim().length > 0 ? componentName : DEFAULT_COMPONENT_NAME;
+
+  if (enabled) {
+    renderStartRef.current = performance.now();
+  }
+
+  useIsomorphicLayoutEffect(() => {
+    if (!enabled) return;
+
+    const elapsedMs = performance.now() - renderStartRef.current;
+
+    if (elapsedMs <= normalizedBudget) return;
+
+    const message =
+      `⚠️ [useRenderBudget] ${normalizedName} exceeded budget: ${formatMs(elapsedMs)}ms ` +
+      `(budget: ${formatMs(normalizedBudget)}ms)`;
+
+    if (strict) {
+      throw new Error(message);
+    }
+
+    console.warn(message);
+  });
+}

--- a/src/hooks/useRenderBudget/useRenderBudget.test.tsx
+++ b/src/hooks/useRenderBudget/useRenderBudget.test.tsx
@@ -1,0 +1,100 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useRenderBudget } from './index';
+
+function burnCpu(ms: number): void {
+  const start = Date.now();
+  while (Date.now() - start < ms) {
+    // Deliberate sync work to make render exceed small budgets in a deterministic way.
+  }
+}
+
+describe('useRenderBudget', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('warns when render duration exceeds the default budget (16ms)', () => {
+    renderHook(() => {
+      useRenderBudget(undefined, 'MyComponent');
+      burnCpu(20);
+    });
+
+    expect(console.warn).toHaveBeenCalled();
+    const message = String(vi.mocked(console.warn).mock.calls[0]?.[0]);
+
+    expect(message).toContain('MyComponent');
+    expect(message).toContain('budget: 16ms');
+    expect(message).toMatch(/exceeded budget: \d+(\.\d+)?ms/);
+  });
+
+  it('respects a custom budget', () => {
+    renderHook(() => {
+      useRenderBudget(1, 'CustomBudgetComponent');
+      burnCpu(8);
+    });
+
+    expect(console.warn).toHaveBeenCalled();
+    const message = String(vi.mocked(console.warn).mock.calls[0]?.[0]);
+
+    expect(message).toContain('CustomBudgetComponent');
+    expect(message).toContain('budget: 1ms');
+  });
+
+  it('does not warn when commit time stays within budget', () => {
+    renderHook(() => useRenderBudget(200, 'FastComponent'));
+
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('throws instead of warning when strict mode is enabled', () => {
+    expect(() =>
+      renderHook(() => {
+        useRenderBudget(1, 'StrictComponent', { strict: true });
+        burnCpu(8);
+      })
+    ).toThrow('[useRenderBudget] StrictComponent exceeded budget');
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op in production by default', () => {
+    process.env.NODE_ENV = 'production';
+
+    expect(() =>
+      renderHook(() => {
+        useRenderBudget(1, 'ProductionComponent', { strict: true });
+        burnCpu(8);
+      })
+    ).not.toThrow();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('can be force-enabled in production via options.enabled', () => {
+    process.env.NODE_ENV = 'production';
+
+    renderHook(() => {
+      useRenderBudget(1, 'ProductionDebugComponent', { enabled: true });
+      burnCpu(8);
+    });
+
+    expect(console.warn).toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('ProductionDebugComponent'));
+  });
+
+  it('falls back to the default component name when an empty label is passed', () => {
+    renderHook(() => {
+      useRenderBudget(1, '   ');
+      burnCpu(8);
+    });
+
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('[useRenderBudget] Component exceeded budget'));
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 export { useRenderTracker } from './hooks/useRenderTracker';
 export type { RenderInfo, UseRenderTrackerOptions } from './hooks/useRenderTracker';
 
+export { useRenderBudget } from './hooks/useRenderBudget';
+export type { UseRenderBudgetOptions } from './hooks/useRenderBudget';
+
 export { usePerformanceMark } from './hooks/usePerformanceMark';
 export type { PerformanceMeasureResult, UsePerformanceMarkReturn } from './hooks/usePerformanceMark';
 


### PR DESCRIPTION
Introduces a new hook to measure and warn about components exceeding render time budgets. This helps catch performance regressions early during development.