### PR TITLE
feat: add useINP hook for interaction tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ npm install web-vitals
 | `useComponentLifecycle` | Track mount/unmount timings and live component lifetime | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-component-lifecycle) |
 | `useMemoProfiling` | Profile `useMemo` cache hits/misses and recomputation costs | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-memo-profiling) |
 | `useWebVitals` | Live Core Web Vitals (LCP, CLS, INP, FCP, TTFB) as React state | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-web-vitals) |
+| `useINP` | Native Interaction to Next Paint tracking with PerformanceObserver event entries | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-inp) |
 | `useDebouncedState` | Debounced `useState` with render-skip profiling counters | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-debounced-state) |
 | `useThrottledState` | Throttled `useState` with dropped-update profiling counters | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-throttled-state) |
 | `useIntersectionObserver` | Lazy-loading visibility state plus first-visible and total-visible metrics | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-intersection-observer) |
@@ -63,6 +64,7 @@ import {
   useComponentLifecycle,
   useMemoProfiling,
   useWebVitals,
+  useINP,
   useDebouncedState,
   useThrottledState,
   useIntersectionObserver,
@@ -87,6 +89,11 @@ function App() {
   // Subscribe to Core Web Vitals and report to analytics
   const vitals = useWebVitals({
     onMetric: (m) => navigator.sendBeacon('/analytics', JSON.stringify(m)),
+  });
+
+  // Track the current page's worst Interaction to Next Paint
+  const inp = useINP({
+    onMetric: (m) => navigator.sendBeacon('/analytics/inp', JSON.stringify(m)),
   });
 
   // Debounce state updates and inspect profiling counters
@@ -114,6 +121,8 @@ function App() {
 
 `useRenderBudget` demo: [docs/demos/useRenderBudgetDemo.tsx](./docs/demos/useRenderBudgetDemo.tsx)
 
+`useINP` demo: [docs/demos/useINPDemo.tsx](./docs/demos/useINPDemo.tsx)
+
 ---
 
 ## TypeScript
@@ -133,6 +142,10 @@ import type {
   WebVitalsState,
   UseWebVitalsOptions,
   VitalRating,
+  INPMetric,
+  INPRating,
+  UseINPOptions,
+  UseINPReturn,
   DebouncedStateStats,
   UseDebouncedStateReturn,
   ThrottledStateStats,

--- a/docs/demos/useINPDemo.tsx
+++ b/docs/demos/useINPDemo.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useINP } from 'react-perf-hooks';
+
+export function UseINPDemo() {
+  const { metric, value, rating, isSupported } = useINP({ durationThreshold: 16 });
+
+  return (
+    <section style={{ fontFamily: 'system-ui, sans-serif', maxWidth: 560, margin: '0 auto' }}>
+      <h2>useINP demo</h2>
+      <p>Click the buttons or type in the input to generate Event Timing entries.</p>
+
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 16 }}>
+        <button type="button" onClick={() => expensiveWork(80)}>
+          Simulate 80ms click
+        </button>
+        <button type="button" onClick={() => expensiveWork(220)}>
+          Simulate 220ms click
+        </button>
+        <input placeholder="Type here" onKeyDown={() => expensiveWork(60)} />
+      </div>
+
+      {!isSupported ? (
+        <p>Event Timing is not supported in this browser.</p>
+      ) : (
+        <dl>
+          <dt>INP</dt>
+          <dd>{value === null ? 'waiting' : `${value.toFixed(0)} ms (${rating})`}</dd>
+          <dt>Worst event</dt>
+          <dd>{metric ? metric.eventType : 'waiting'}</dd>
+          <dt>Interaction ID</dt>
+          <dd>{metric?.interactionId ?? 'not exposed yet'}</dd>
+        </dl>
+      )}
+    </section>
+  );
+}
+
+function expensiveWork(duration: number): void {
+  const end = performance.now() + duration;
+  while (performance.now() < end) {
+    // Intentionally block the main thread so the demo has visible INP movement.
+  }
+}
+
+export default UseINPDemo;

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ A focused collection of React hooks for **performance monitoring, profiling, and
 | [useComponentLifecycle](./useComponentLifecycle.md) | Track mount and unmount times, plus live lifetime since mount |
 | [useMemoProfiling](./useMemoProfiling.md) | Profile `useMemo` cache effectiveness with HIT/MISS stats |
 | [useWebVitals](./useWebVitals.md) | Subscribe to all five Core Web Vitals as reactive React state |
+| [useINP](./useINP.md) | Track Interaction to Next Paint from native Event Timing entries |
 | [useDebouncedState](./useDebouncedState.md) | Debounced `useState` replacement with skipped-render profiling |
 | [useThrottledState](./useThrottledState.md) | Throttled `useState` replacement with dropped-update profiling |
 | [useIntersectionObserver](./useIntersectionObserver.md) | Observe element visibility and collect first-visible and total-visible metrics |
@@ -40,6 +41,7 @@ import {
   useComponentLifecycle,
   useMemoProfiling,
   useWebVitals,
+  useINP,
   useDebouncedState,
   useThrottledState,
   useIntersectionObserver,
@@ -65,6 +67,10 @@ import type {
   WebVitalsState,
   UseWebVitalsOptions,
   VitalRating,
+  INPMetric,
+  INPRating,
+  UseINPOptions,
+  UseINPReturn,
   DebouncedStateStats,
   UseDebouncedStateReturn,
   ThrottledStateStats,

--- a/docs/useINP.md
+++ b/docs/useINP.md
@@ -1,0 +1,145 @@
+# useINP
+
+Tracks **Interaction to Next Paint (INP)** using the browser Event Timing API. The hook keeps the worst interaction observed during the current page view and exposes it as React state.
+
+## Why use it?
+
+INP is the Core Web Vitals responsiveness metric. It captures how long a user interaction takes from the browser receiving input until the next paint can show the result.
+
+Use `useINP` when you want to:
+
+- Build a live responsiveness overlay without installing `web-vitals`
+- Send the worst interaction latency to your analytics pipeline
+- Spot slow clicks, taps, and key presses while developing React UI
+
+> Browser support depends on `PerformanceObserver` support for the `event` entry type. The hook returns `isSupported: false` when unavailable.
+
+---
+
+## Import
+
+```ts
+import { useINP } from 'react-perf-hooks';
+```
+
+---
+
+## Signature
+
+```ts
+function useINP(options?: UseINPOptions): UseINPReturn
+```
+
+---
+
+## Parameters — `UseINPOptions`
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `onMetric` | `(metric: INPMetric) => void` | — | Called whenever the worst observed interaction changes. |
+| `durationThreshold` | `number` | `40` | Minimum event duration observed by the browser, in milliseconds. Lower values capture more entries but can add overhead. |
+| `enabled` | `boolean` | `true` | Set to `false` to skip subscribing entirely. |
+
+---
+
+## Return value — `UseINPReturn`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `metric` | `INPMetric \| null` | The worst INP interaction seen so far. |
+| `value` | `number \| null` | Convenience value from `metric.value`, in milliseconds. |
+| `rating` | `INPRating \| null` | `"good"`, `"needs-improvement"`, or `"poor"`. |
+| `isSupported` | `boolean` | Whether the browser supports Event Timing entries. |
+
+---
+
+## `INPMetric`
+
+```ts
+interface INPMetric {
+  name: 'INP';
+  value: number;
+  rating: 'good' | 'needs-improvement' | 'poor';
+  eventType: string;
+  startTime: number;
+  interactionId: number | null;
+  timestamp: number;
+}
+```
+
+## Rating thresholds
+
+| Rating | INP value |
+|--------|-----------|
+| `good` | < 200 ms |
+| `needs-improvement` | 200-500 ms |
+| `poor` | > 500 ms |
+
+---
+
+## Examples
+
+### Live INP badge
+
+```tsx
+import { useINP } from 'react-perf-hooks';
+
+function INPBadge() {
+  const { value, rating, isSupported } = useINP();
+
+  if (!isSupported) {
+    return <span>INP unavailable</span>;
+  }
+
+  return (
+    <span>
+      INP: {value === null ? 'waiting...' : `${value.toFixed(0)} ms (${rating})`}
+    </span>
+  );
+}
+```
+
+### Report to analytics
+
+```tsx
+import { useINP } from 'react-perf-hooks';
+
+function App() {
+  useINP({
+    onMetric(metric) {
+      navigator.sendBeacon(
+        '/api/inp',
+        JSON.stringify({
+          url: location.href,
+          ...metric,
+        })
+      );
+    },
+  });
+
+  return <RouterProvider router={router} />;
+}
+```
+
+### Lower the observation threshold in development
+
+```tsx
+import { useINP } from 'react-perf-hooks';
+
+function DevOverlay() {
+  const { metric } = useINP({
+    durationThreshold: 16,
+    enabled: process.env.NODE_ENV === 'development',
+  });
+
+  return <pre>{JSON.stringify(metric, null, 2)}</pre>;
+}
+```
+
+---
+
+## Notes
+
+- The hook tracks the worst observed interaction, matching INP's "page responsiveness" mental model.
+- `durationThreshold` is passed to `PerformanceObserver.observe()`.
+- Event Timing duration is measured by the browser from interaction start through presentation of the next paint.

--- a/examples/stackblitz/hooks-playground/src/App.tsx
+++ b/examples/stackblitz/hooks-playground/src/App.tsx
@@ -8,6 +8,7 @@ import {UseRenderBudgetDemo} from './demos/useRenderBudgetDemo';
 import {UseRenderTrackerDemo} from './demos/useRenderTrackerDemo';
 import {UseThrottledStateDemo} from './demos/useThrottledStateDemo';
 import {UseWebVitalsDemo} from './demos/useWebVitalsDemo';
+import {UseINPDemo} from './demos/useINPDemo';
 
 type DemoKey =
   | 'useRenderTracker'
@@ -16,6 +17,7 @@ type DemoKey =
   | 'useComponentLifecycle'
   | 'useMemoProfiling'
   | 'useWebVitals'
+  | 'useINP'
   | 'useDebouncedState'
   | 'useThrottledState'
   | 'useIntersectionObserver';
@@ -27,6 +29,7 @@ const demos: Record<DemoKey, {label: string; Component: () => JSX.Element}> = {
   useComponentLifecycle: {label: 'useComponentLifecycle', Component: UseComponentLifecycleDemo},
   useMemoProfiling: {label: 'useMemoProfiling', Component: UseMemoProfilingDemo},
   useWebVitals: {label: 'useWebVitals', Component: UseWebVitalsDemo},
+  useINP: {label: 'useINP', Component: UseINPDemo},
   useDebouncedState: {label: 'useDebouncedState', Component: UseDebouncedStateDemo},
   useThrottledState: {label: 'useThrottledState', Component: UseThrottledStateDemo},
   useIntersectionObserver: {label: 'useIntersectionObserver', Component: UseIntersectionObserverDemo},

--- a/examples/stackblitz/hooks-playground/src/demos/useINPDemo.tsx
+++ b/examples/stackblitz/hooks-playground/src/demos/useINPDemo.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {useINP} from 'react-perf-hooks';
+
+export function UseINPDemo() {
+  const {metric, value, rating, isSupported} = useINP({durationThreshold: 16});
+
+  return (
+    <section style={{fontFamily: 'system-ui, sans-serif', maxWidth: 560, margin: '0 auto'}}>
+      <h2>useINP demo</h2>
+      <p>Click the buttons or type in the input to generate Event Timing entries.</p>
+
+      <div style={{display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 16}}>
+        <button type="button" onClick={() => expensiveWork(80)}>
+          Simulate 80ms click
+        </button>
+        <button type="button" onClick={() => expensiveWork(220)}>
+          Simulate 220ms click
+        </button>
+        <input placeholder="Type here" onKeyDown={() => expensiveWork(60)} />
+      </div>
+
+      {!isSupported ? (
+        <p>Event Timing is not supported in this browser.</p>
+      ) : (
+        <dl>
+          <dt>INP</dt>
+          <dd>{value === null ? 'waiting' : `${value.toFixed(0)} ms (${rating})`}</dd>
+          <dt>Worst event</dt>
+          <dd>{metric ? metric.eventType : 'waiting'}</dd>
+          <dt>Interaction ID</dt>
+          <dd>{metric?.interactionId ?? 'not exposed yet'}</dd>
+        </dl>
+      )}
+    </section>
+  );
+}
+
+function expensiveWork(duration: number): void {
+  const end = performance.now() + duration;
+  while (performance.now() < end) {
+    // Intentionally block the main thread so the demo has visible INP movement.
+  }
+}

--- a/src/hooks/useINP/index.ts
+++ b/src/hooks/useINP/index.ts
@@ -136,7 +136,10 @@ export function useINP(options: UseINPOptions = {}): UseINPReturn {
     const Observer = PerformanceObserver as PerformanceObserverConstructorLike;
     const observer = new Observer((list) => {
       for (const entry of list.getEntries()) {
-        updateMetric(entry as PerformanceEventTimingLike);
+        const eventEntry = entry as PerformanceEventTimingLike;
+        if (typeof eventEntry.interactionId !== 'number' || eventEntry.interactionId <= 0) continue;
+
+        updateMetric(eventEntry);
       }
     });
 

--- a/src/hooks/useINP/index.ts
+++ b/src/hooks/useINP/index.ts
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type INPRating = 'good' | 'needs-improvement' | 'poor';
+
+export interface INPMetric {
+  /** Always `INP` for easy analytics payloads. */
+  name: 'INP';
+  /** Interaction to Next Paint latency in milliseconds. */
+  value: number;
+  /** Google's INP rating thresholds: good < 200ms, poor > 500ms. */
+  rating: INPRating;
+  /** Event type that produced the current worst interaction. */
+  eventType: string;
+  /** Absolute event start time in milliseconds from navigation start. */
+  startTime: number;
+  /** Event interactionId when the browser exposes one. */
+  interactionId: number | null;
+  /** Time when this hook converted the browser entry into state. */
+  timestamp: number;
+}
+
+export interface UseINPOptions {
+  /**
+   * Called whenever the page's worst interaction changes.
+   * Use this for analytics or dev overlays.
+   */
+  onMetric?: (metric: INPMetric) => void;
+  /**
+   * Minimum event duration observed by the browser. Lower values can capture
+   * more interactions but may add overhead. Defaults to `40`.
+   */
+  durationThreshold?: number;
+  /**
+   * Set to `false` to disable the observer entirely.
+   * Defaults to `true`.
+   */
+  enabled?: boolean;
+}
+
+export interface UseINPReturn {
+  /** The worst INP metric seen so far, or `null` until the first qualifying interaction. */
+  metric: INPMetric | null;
+  /** Convenience value from `metric.value`. */
+  value: number | null;
+  /** Convenience value from `metric.rating`. */
+  rating: INPRating | null;
+  /** Whether this browser can observe Event Timing entries. */
+  isSupported: boolean;
+}
+
+interface PerformanceEventTimingLike extends PerformanceEntry {
+  interactionId?: number;
+}
+
+interface PerformanceObserverEntryListLike {
+  getEntries: () => PerformanceEntry[];
+}
+
+type PerformanceObserverCallbackLike = (list: PerformanceObserverEntryListLike, observer: PerformanceObserver) => void;
+
+type PerformanceObserverConstructorLike = {
+  new (callback: PerformanceObserverCallbackLike): PerformanceObserver;
+  supportedEntryTypes?: readonly string[];
+};
+
+const DEFAULT_DURATION_THRESHOLD = 40;
+const INP_GOOD_THRESHOLD = 200;
+const INP_POOR_THRESHOLD = 500;
+
+function getINPRating(value: number): INPRating {
+  if (value < INP_GOOD_THRESHOLD) return 'good';
+  if (value <= INP_POOR_THRESHOLD) return 'needs-improvement';
+  return 'poor';
+}
+
+function getNow(): number {
+  return typeof performance !== 'undefined' && typeof performance.now === 'function' ? performance.now() : Date.now();
+}
+
+function supportsEventTiming(): boolean {
+  if (typeof window === 'undefined' || typeof PerformanceObserver === 'undefined') {
+    return false;
+  }
+
+  const Observer = PerformanceObserver as PerformanceObserverConstructorLike;
+  return Array.isArray(Observer.supportedEntryTypes) && Observer.supportedEntryTypes.includes('event');
+}
+
+function toINPMetric(entry: PerformanceEventTimingLike): INPMetric {
+  return {
+    name: 'INP',
+    value: entry.duration,
+    rating: getINPRating(entry.duration),
+    eventType: entry.name,
+    startTime: entry.startTime,
+    interactionId: typeof entry.interactionId === 'number' && entry.interactionId > 0 ? entry.interactionId : null,
+    timestamp: getNow(),
+  };
+}
+
+/**
+ * Tracks Interaction to Next Paint (INP) from native Event Timing entries.
+ * The hook keeps the worst observed interaction for the current page view and
+ * updates when a click, tap, or key interaction takes longer than the current worst value.
+ *
+ * @example
+ * function INPBadge() {
+ *   const { value, rating } = useINP();
+ *
+ *   return <span>INP: {value ? `${value.toFixed(0)} ms (${rating})` : 'waiting'}</span>;
+ * }
+ */
+export function useINP(options: UseINPOptions = {}): UseINPReturn {
+  const { onMetric, durationThreshold = DEFAULT_DURATION_THRESHOLD, enabled = true } = options;
+  const [metric, setMetric] = useState<INPMetric | null>(null);
+  const worstValueRef = useRef(0);
+  const onMetricRef = useRef(onMetric);
+  const isSupported = supportsEventTiming();
+
+  useEffect(() => {
+    onMetricRef.current = onMetric;
+  }, [onMetric]);
+
+  const updateMetric = useCallback((entry: PerformanceEventTimingLike) => {
+    if (entry.duration <= worstValueRef.current) return;
+
+    const nextMetric = toINPMetric(entry);
+    worstValueRef.current = nextMetric.value;
+    setMetric(nextMetric);
+    onMetricRef.current?.(nextMetric);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !isSupported) return;
+
+    const Observer = PerformanceObserver as PerformanceObserverConstructorLike;
+    const observer = new Observer((list) => {
+      for (const entry of list.getEntries()) {
+        updateMetric(entry as PerformanceEventTimingLike);
+      }
+    });
+
+    observer.observe({
+      type: 'event',
+      buffered: true,
+      durationThreshold,
+    } as PerformanceObserverInit);
+
+    return () => observer.disconnect();
+  }, [durationThreshold, enabled, isSupported, updateMetric]);
+
+  return {
+    metric,
+    value: metric?.value ?? null,
+    rating: metric?.rating ?? null,
+    isSupported,
+  };
+}

--- a/src/hooks/useINP/useINP.test.tsx
+++ b/src/hooks/useINP/useINP.test.tsx
@@ -143,12 +143,15 @@ describe('useINP', () => {
     expect(onMetric).toHaveBeenLastCalledWith(expect.objectContaining({ value: 350 }));
   });
 
-  it('reports null interactionId when the browser does not expose a positive id', () => {
-    const { result } = renderHook(() => useINP());
+  it('ignores entries without a positive interaction id', () => {
+    const onMetric = vi.fn();
+    const { result } = renderHook(() => useINP({ onMetric }));
 
     emitEntry({ name: 'click', duration: 120, startTime: 10, interactionId: 0 });
+    emitEntry({ name: 'pointerover', duration: 400, startTime: 20 });
 
-    expect(result.current.metric?.interactionId).toBeNull();
+    expect(result.current.metric).toBeNull();
+    expect(onMetric).not.toHaveBeenCalled();
   });
 
   it('does not subscribe when enabled=false', () => {

--- a/src/hooks/useINP/useINP.test.tsx
+++ b/src/hooks/useINP/useINP.test.tsx
@@ -1,0 +1,177 @@
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useINP } from './index';
+
+type ObserverCallback = (list: { getEntries: () => PerformanceEntry[] }, observer: PerformanceObserver) => void;
+
+const originalPerformanceObserver = globalThis.PerformanceObserver;
+
+class MockPerformanceObserver {
+  static supportedEntryTypes = ['event'];
+  static callback: ObserverCallback | null = null;
+  static observe = vi.fn();
+  static disconnect = vi.fn();
+
+  constructor(callback: ObserverCallback) {
+    MockPerformanceObserver.callback = callback;
+  }
+
+  observe(options: PerformanceObserverInit): void {
+    MockPerformanceObserver.observe(options);
+  }
+
+  disconnect(): void {
+    MockPerformanceObserver.disconnect();
+  }
+}
+
+function setMockPerformanceObserver(entryTypes: string[] = ['event']): void {
+  MockPerformanceObserver.supportedEntryTypes = entryTypes;
+  globalThis.PerformanceObserver = MockPerformanceObserver as unknown as typeof PerformanceObserver;
+}
+
+function emitEntry(entry: Partial<PerformanceEntry> & { interactionId?: number }): void {
+  act(() => {
+    MockPerformanceObserver.callback?.(
+      {
+        getEntries: () => [entry as PerformanceEntry],
+      },
+      {} as PerformanceObserver
+    );
+  });
+}
+
+describe('useINP', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    MockPerformanceObserver.callback = null;
+    setMockPerformanceObserver();
+  });
+
+  afterEach(() => {
+    globalThis.PerformanceObserver = originalPerformanceObserver;
+  });
+
+  it('returns null values before the first interaction', () => {
+    const { result } = renderHook(() => useINP());
+
+    expect(result.current.metric).toBeNull();
+    expect(result.current.value).toBeNull();
+    expect(result.current.rating).toBeNull();
+    expect(result.current.isSupported).toBe(true);
+  });
+
+  it('observes Event Timing entries with buffered events and a default duration threshold', () => {
+    renderHook(() => useINP());
+
+    expect(MockPerformanceObserver.observe).toHaveBeenCalledWith({
+      type: 'event',
+      buffered: true,
+      durationThreshold: 40,
+    });
+  });
+
+  it('uses a custom duration threshold', () => {
+    renderHook(() => useINP({ durationThreshold: 16 }));
+
+    expect(MockPerformanceObserver.observe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        durationThreshold: 16,
+      })
+    );
+  });
+
+  it('updates with the first qualifying interaction', () => {
+    const { result } = renderHook(() => useINP());
+
+    emitEntry({
+      name: 'click',
+      duration: 180,
+      startTime: 120,
+      interactionId: 42,
+    });
+
+    expect(result.current.metric).toMatchObject({
+      name: 'INP',
+      value: 180,
+      rating: 'good',
+      eventType: 'click',
+      startTime: 120,
+      interactionId: 42,
+    });
+    expect(result.current.value).toBe(180);
+    expect(result.current.rating).toBe('good');
+  });
+
+  it('keeps the worst interaction instead of replacing it with a faster one', () => {
+    const { result } = renderHook(() => useINP());
+
+    emitEntry({ name: 'keydown', duration: 260, startTime: 10, interactionId: 1 });
+    emitEntry({ name: 'click', duration: 90, startTime: 20, interactionId: 2 });
+
+    expect(result.current.metric).toMatchObject({
+      value: 260,
+      rating: 'needs-improvement',
+      eventType: 'keydown',
+      interactionId: 1,
+    });
+  });
+
+  it('updates when a later interaction is worse', () => {
+    const { result } = renderHook(() => useINP());
+
+    emitEntry({ name: 'click', duration: 250, startTime: 10, interactionId: 1 });
+    emitEntry({ name: 'pointerdown', duration: 520, startTime: 20, interactionId: 2 });
+
+    expect(result.current.metric).toMatchObject({
+      value: 520,
+      rating: 'poor',
+      eventType: 'pointerdown',
+      interactionId: 2,
+    });
+  });
+
+  it('calls onMetric only when the worst interaction changes', () => {
+    const onMetric = vi.fn();
+    renderHook(() => useINP({ onMetric }));
+
+    emitEntry({ name: 'click', duration: 220, startTime: 10, interactionId: 1 });
+    emitEntry({ name: 'keydown', duration: 200, startTime: 20, interactionId: 2 });
+    emitEntry({ name: 'click', duration: 350, startTime: 30, interactionId: 3 });
+
+    expect(onMetric).toHaveBeenCalledTimes(2);
+    expect(onMetric).toHaveBeenLastCalledWith(expect.objectContaining({ value: 350 }));
+  });
+
+  it('reports null interactionId when the browser does not expose a positive id', () => {
+    const { result } = renderHook(() => useINP());
+
+    emitEntry({ name: 'click', duration: 120, startTime: 10, interactionId: 0 });
+
+    expect(result.current.metric?.interactionId).toBeNull();
+  });
+
+  it('does not subscribe when enabled=false', () => {
+    const { result } = renderHook(() => useINP({ enabled: false }));
+
+    expect(result.current.isSupported).toBe(true);
+    expect(MockPerformanceObserver.observe).not.toHaveBeenCalled();
+  });
+
+  it('returns unsupported state when Event Timing is unavailable', () => {
+    setMockPerformanceObserver(['paint']);
+
+    const { result } = renderHook(() => useINP());
+
+    expect(result.current.isSupported).toBe(false);
+    expect(MockPerformanceObserver.observe).not.toHaveBeenCalled();
+  });
+
+  it('disconnects the observer on unmount', () => {
+    const { unmount } = renderHook(() => useINP());
+
+    unmount();
+
+    expect(MockPerformanceObserver.disconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,9 @@ export type { MemoProfilingStats } from './hooks/useMemoProfiling';
 export { useWebVitals } from './hooks/useWebVitals';
 export type { WebVitalMetric, WebVitalsState, UseWebVitalsOptions, VitalRating } from './hooks/useWebVitals';
 
+export { useINP } from './hooks/useINP';
+export type { INPMetric, INPRating, UseINPOptions, UseINPReturn } from './hooks/useINP';
+
 export { useDebouncedState } from './hooks/useDebouncedState';
 export type { DebouncedStateStats, UseDebouncedStateReturn } from './hooks/useDebouncedState';
 

--- a/website/docs/hooks/use-inp.mdx
+++ b/website/docs/hooks/use-inp.mdx
@@ -1,0 +1,67 @@
+---
+title: useINP
+description: Track Interaction to Next Paint from native Event Timing entries.
+---
+
+import StackBlitzEmbed from '@site/src/components/StackBlitzEmbed';
+
+## Description and use case
+
+`useINP` tracks the worst Interaction to Next Paint observed during the current page view. It uses `PerformanceObserver` with the `event` entry type, so it does not require the `web-vitals` package.
+
+## API signature
+
+```ts
+function useINP(options?: UseINPOptions): UseINPReturn
+```
+
+## Parameters
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `options.onMetric` | `(metric: INPMetric) => void` | No | Callback fired whenever the worst interaction changes. |
+| `options.durationThreshold` | `number` | No | Minimum Event Timing duration observed by the browser. Defaults to `40`. |
+| `options.enabled` | `boolean` | No | Set `false` to disable the observer. |
+
+## Return value
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `metric` | `INPMetric \| null` | Worst interaction metric seen so far. |
+| `value` | `number \| null` | INP latency in milliseconds. |
+| `rating` | `INPRating \| null` | `good`, `needs-improvement`, or `poor`. |
+| `isSupported` | `boolean` | Whether this browser supports Event Timing entries. |
+
+## Live interactive demo (StackBlitz)
+
+<StackBlitzEmbed
+  title="useINP demo"
+  src="https://stackblitz.com/github/valyefimov/react-perf-hooks/tree/main/examples/stackblitz/hooks-playground?file=src/App.tsx&embed=1&view=preview&startScript=dev&demo=useINP"
+  openHref="https://stackblitz.com/github/valyefimov/react-perf-hooks/tree/main/examples/stackblitz/hooks-playground?file=src/App.tsx&startScript=dev&demo=useINP"
+/>
+
+## Code example
+
+```tsx
+import {useINP} from 'react-perf-hooks';
+
+export function INPOverlay() {
+  const {value, rating, isSupported} = useINP({
+    durationThreshold: 16,
+    onMetric: (metric) => {
+      navigator.sendBeacon('/api/inp', JSON.stringify(metric));
+    },
+  });
+
+  if (!isSupported) {
+    return <p>INP is not available in this browser.</p>;
+  }
+
+  return <p>INP: {value === null ? 'waiting' : `${value.toFixed(0)} ms (${rating})`}</p>;
+}
+```
+
+## Companion article
+
+- [dev.to companion article](https://dev.to/search?q=useINP)
+- [Medium companion article](https://medium.com/search?q=useINP)

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -14,6 +14,7 @@ const sidebars: SidebarsConfig = {
         'hooks/use-component-lifecycle',
         'hooks/use-memo-profiling',
         'hooks/use-web-vitals',
+        'hooks/use-inp',
         'hooks/use-debounced-state',
         'hooks/use-throttled-state',
         'hooks/use-intersection-observer',

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -12,6 +12,7 @@ const hooks = [
   'useComponentLifecycle',
   'useMemoProfiling',
   'useWebVitals',
+  'useINP',
   'useDebouncedState',
   'useThrottledState',
   'useIntersectionObserver',
@@ -51,7 +52,7 @@ export default function Home(): ReactNode {
           <Heading as="h2">What this docs site includes</Heading>
           <div className={styles.cardGrid}>
             <article className={styles.card}>
-              <h3>9 hook references</h3>
+              <h3>10 hook references</h3>
               <p>Every hook has signature details, parameter and return tables, and copy-ready usage examples.</p>
             </article>
             <article className={styles.card}>


### PR DESCRIPTION
Implement the `useINP` hook to track the worst Interaction to Next Paint (INP) using the browser's Event Timing API. This includes the hook logic, unit tests, documentation, and a live demo component.