### PR TITLE
feat: add useCLS hook for component-scoped tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ npm install web-vitals
 | `useMemoProfiling` | Profile `useMemo` cache hits/misses and recomputation costs | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-memo-profiling) |
 | `useWebVitals` | Live Core Web Vitals (LCP, CLS, INP, FCP, TTFB) as React state | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-web-vitals) |
 | `useINP` | Native Interaction to Next Paint tracking with PerformanceObserver event entries | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-inp) |
+| `useCLS` | Component-scoped Cumulative Layout Shift tracking for a specific DOM node | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-cls) |
 | `useDebouncedState` | Debounced `useState` with render-skip profiling counters | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-debounced-state) |
 | `useThrottledState` | Throttled `useState` with dropped-update profiling counters | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-throttled-state) |
 | `useIntersectionObserver` | Lazy-loading visibility state plus first-visible and total-visible metrics | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-intersection-observer) |
@@ -65,6 +66,7 @@ import {
   useMemoProfiling,
   useWebVitals,
   useINP,
+  useCLS,
   useDebouncedState,
   useThrottledState,
   useIntersectionObserver,
@@ -96,6 +98,11 @@ function App() {
     onMetric: (m) => navigator.sendBeacon('/analytics/inp', JSON.stringify(m)),
   });
 
+  // Track Cumulative Layout Shift for one component root
+  const cls = useCLS<HTMLDivElement>({
+    onMetric: (m) => navigator.sendBeacon('/analytics/cls/component', JSON.stringify(m)),
+  });
+
   // Debounce state updates and inspect profiling counters
   const [query, setQuery, stats] = useDebouncedState('', 250);
 
@@ -105,7 +112,7 @@ function App() {
   // Track when an element first becomes visible and for how long it stays visible
   const { ref, isVisible, metrics } = useIntersectionObserver({ threshold: 0.25 });
 
-  return <div>...</div>;
+  return <div ref={cls.ref}>...</div>;
 }
 ```
 
@@ -122,6 +129,8 @@ function App() {
 `useRenderBudget` demo: [docs/demos/useRenderBudgetDemo.tsx](./docs/demos/useRenderBudgetDemo.tsx)
 
 `useINP` demo: [docs/demos/useINPDemo.tsx](./docs/demos/useINPDemo.tsx)
+
+`useCLS` demo: [docs/demos/useCLSDemo.tsx](./docs/demos/useCLSDemo.tsx)
 
 ---
 
@@ -146,6 +155,11 @@ import type {
   INPRating,
   UseINPOptions,
   UseINPReturn,
+  CLSAttribution,
+  CLSMetric,
+  CLSRating,
+  UseCLSOptions,
+  UseCLSReturn,
   DebouncedStateStats,
   UseDebouncedStateReturn,
   ThrottledStateStats,

--- a/docs/demos/useCLSDemo.tsx
+++ b/docs/demos/useCLSDemo.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { useCLS } from 'react-perf-hooks';
+
+export function UseCLSDemo() {
+  const [showHero, setShowHero] = useState(false);
+  const [showNotice, setShowNotice] = useState(false);
+  const { ref, value, rating, entries, isSupported } = useCLS<HTMLDivElement>({
+    onMetric: (metric) => {
+      console.info('[useCLS demo]', metric);
+    },
+  });
+
+  return (
+    <section style={{ fontFamily: 'system-ui, sans-serif', maxWidth: 640, margin: '0 auto' }}>
+      <h2>useCLS demo</h2>
+      <p>Toggle delayed content inside the observed card to see component-level layout shift attribution.</p>
+
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 16 }}>
+        <button type="button" onClick={() => setShowHero((current) => !current)}>
+          Toggle unreserved media
+        </button>
+        <button type="button" onClick={() => setShowNotice((current) => !current)}>
+          Toggle notice
+        </button>
+      </div>
+
+      <div
+        ref={ref}
+        style={{
+          border: '1px solid #cbd5e1',
+          borderRadius: 8,
+          padding: 16,
+          background: '#ffffff',
+          boxShadow: '0 1px 3px rgba(15, 23, 42, 0.12)',
+        }}
+      >
+        <h3 style={{ marginTop: 0 }}>Observed product card</h3>
+        {showHero ? (
+          <div
+            style={{
+              height: 140,
+              marginBottom: 12,
+              background: 'linear-gradient(135deg, #0f766e, #2563eb)',
+              borderRadius: 6,
+            }}
+          />
+        ) : null}
+        <p style={{ margin: '0 0 12px' }}>
+          This card intentionally inserts content without reserving space so supported browsers can emit
+          layout-shift entries.
+        </p>
+        {showNotice ? (
+          <p style={{ margin: '0 0 12px', padding: 10, background: '#fef3c7', borderRadius: 6 }}>
+            Dynamic notice loaded after initial content.
+          </p>
+        ) : null}
+        <strong>Component CLS:</strong>{' '}
+        {isSupported ? `${value.toFixed(3)} (${rating ?? 'waiting'})` : 'layout-shift unsupported'}
+      </div>
+
+      <dl>
+        <dt>Matching entries</dt>
+        <dd>{entries.length}</dd>
+        <dt>Latest delta</dt>
+        <dd>{entries.at(-1)?.delta.toFixed(3) ?? 'waiting'}</dd>
+      </dl>
+    </section>
+  );
+}
+
+export default UseCLSDemo;

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ A focused collection of React hooks for **performance monitoring, profiling, and
 | [useMemoProfiling](./useMemoProfiling.md) | Profile `useMemo` cache effectiveness with HIT/MISS stats |
 | [useWebVitals](./useWebVitals.md) | Subscribe to all five Core Web Vitals as reactive React state |
 | [useINP](./useINP.md) | Track Interaction to Next Paint from native Event Timing entries |
+| [useCLS](./useCLS.md) | Track Cumulative Layout Shift for one component root |
 | [useDebouncedState](./useDebouncedState.md) | Debounced `useState` replacement with skipped-render profiling |
 | [useThrottledState](./useThrottledState.md) | Throttled `useState` replacement with dropped-update profiling |
 | [useIntersectionObserver](./useIntersectionObserver.md) | Observe element visibility and collect first-visible and total-visible metrics |
@@ -42,6 +43,7 @@ import {
   useMemoProfiling,
   useWebVitals,
   useINP,
+  useCLS,
   useDebouncedState,
   useThrottledState,
   useIntersectionObserver,
@@ -71,6 +73,11 @@ import type {
   INPRating,
   UseINPOptions,
   UseINPReturn,
+  CLSAttribution,
+  CLSMetric,
+  CLSRating,
+  UseCLSOptions,
+  UseCLSReturn,
   DebouncedStateStats,
   UseDebouncedStateReturn,
   ThrottledStateStats,

--- a/docs/useCLS.md
+++ b/docs/useCLS.md
@@ -1,0 +1,148 @@
+# useCLS
+
+Tracks **Cumulative Layout Shift (CLS)** for a specific component root. Attach the returned `ref` to the DOM node you want to inspect; the hook accumulates layout-shift entries attributed to that element or, by default, its descendants.
+
+## Why use it?
+
+Page-level CLS tells you that something moved. Component-scoped CLS helps you find which card, banner, image, widget, or async content block caused the shift.
+
+Use `useCLS` when you want to:
+
+- Build a live layout-shift overlay for a suspicious component
+- Report component-level CLS attribution to analytics
+- Catch dynamic content that jumps because dimensions were not reserved
+
+> Browser support depends on `PerformanceObserver` support for the `layout-shift` entry type. The hook returns `isSupported: false` when unavailable.
+
+---
+
+## Import
+
+```ts
+import { useCLS } from 'react-perf-hooks';
+```
+
+---
+
+## Signature
+
+```ts
+function useCLS<T extends Element = HTMLElement>(options?: UseCLSOptions): UseCLSReturn<T>
+```
+
+---
+
+## Parameters — `UseCLSOptions`
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `onMetric` | `(metric: CLSMetric) => void` | — | Called whenever a matching layout shift changes the component CLS value. |
+| `includeDescendants` | `boolean` | `true` | Include layout shifts attributed to descendants of the observed element. |
+| `ignoreRecentInput` | `boolean` | `true` | Ignore shifts shortly after user input, matching Core Web Vitals CLS behavior. |
+| `maxEntries` | `number` | `50` | Maximum number of matching layout-shift metrics retained in state. |
+| `enabled` | `boolean` | `true` | Set to `false` to skip subscribing entirely. |
+
+---
+
+## Return value — `UseCLSReturn`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ref` | `(node: T \| null) => void` | Attach to the component root you want to inspect. |
+| `metric` | `CLSMetric \| null` | Latest cumulative CLS metric for the observed element. |
+| `value` | `number` | Current cumulative CLS value. Starts at `0`. |
+| `rating` | `CLSRating \| null` | `"good"`, `"needs-improvement"`, or `"poor"`. |
+| `entries` | `CLSMetric[]` | Matching layout-shift metrics retained for debugging. |
+| `isSupported` | `boolean` | Whether the browser supports Layout Instability entries. |
+
+---
+
+## `CLSMetric`
+
+```ts
+interface CLSMetric {
+  name: 'CLS';
+  value: number;
+  delta: number;
+  rating: 'good' | 'needs-improvement' | 'poor';
+  startTime: number;
+  hadRecentInput: boolean;
+  sources: CLSAttribution[];
+  timestamp: number;
+}
+```
+
+## Rating thresholds
+
+| Rating | CLS value |
+|--------|-----------|
+| `good` | < 0.1 |
+| `needs-improvement` | 0.1-0.25 |
+| `poor` | > 0.25 |
+
+---
+
+## Examples
+
+### Find a jumping component
+
+```tsx
+import { useCLS } from 'react-perf-hooks';
+
+function ProductCard() {
+  const { ref, value, rating, isSupported } = useCLS<HTMLDivElement>();
+
+  return (
+    <article ref={ref}>
+      <img src="/product.jpg" alt="" />
+      <strong>Component CLS</strong>
+      <span>{isSupported ? `${value.toFixed(3)} (${rating ?? 'waiting'})` : 'unavailable'}</span>
+    </article>
+  );
+}
+```
+
+### Report component-level shifts
+
+```tsx
+import { useCLS } from 'react-perf-hooks';
+
+function PromoBanner() {
+  const { ref } = useCLS<HTMLDivElement>({
+    onMetric(metric) {
+      navigator.sendBeacon(
+        '/api/component-cls',
+        JSON.stringify({
+          component: 'PromoBanner',
+          url: location.href,
+          ...metric,
+        })
+      );
+    },
+  });
+
+  return <div ref={ref}>...</div>;
+}
+```
+
+### Only track the root element
+
+```tsx
+import { useCLS } from 'react-perf-hooks';
+
+function Shell() {
+  const cls = useCLS<HTMLElement>({
+    includeDescendants: false,
+  });
+
+  return <main ref={cls.ref}>...</main>;
+}
+```
+
+---
+
+## Notes
+
+- `useCLS` relies on layout-shift attribution sources. Entries with no matching source are ignored.
+- By default, descendant attribution is included because the browser often reports the shifted child node rather than the component root.
+- `ignoreRecentInput` defaults to `true` so the value follows Core Web Vitals CLS semantics.

--- a/docs/useCLS.md
+++ b/docs/useCLS.md
@@ -1,6 +1,6 @@
 # useCLS
 
-Tracks **Cumulative Layout Shift (CLS)** for a specific component root. Attach the returned `ref` to the DOM node you want to inspect; the hook accumulates layout-shift entries attributed to that element or, by default, its descendants.
+Tracks **Cumulative Layout Shift (CLS)** for a specific component root. Attach the returned `ref` to the DOM node you want to inspect; the hook reports the largest CLS session window for layout-shift entries attributed to that element or, by default, its descendants.
 
 ## Why use it?
 
@@ -49,8 +49,8 @@ function useCLS<T extends Element = HTMLElement>(options?: UseCLSOptions): UseCL
 | Field | Type | Description |
 |-------|------|-------------|
 | `ref` | `(node: T \| null) => void` | Attach to the component root you want to inspect. |
-| `metric` | `CLSMetric \| null` | Latest cumulative CLS metric for the observed element. |
-| `value` | `number` | Current cumulative CLS value. Starts at `0`. |
+| `metric` | `CLSMetric \| null` | Latest CLS metric for the observed element, scored by largest session window. |
+| `value` | `number` | Current largest CLS session-window value. Starts at `0`. |
 | `rating` | `CLSRating \| null` | `"good"`, `"needs-improvement"`, or `"poor"`. |
 | `entries` | `CLSMetric[]` | Matching layout-shift metrics retained for debugging. |
 | `isSupported` | `boolean` | Whether the browser supports Layout Instability entries. |
@@ -146,3 +146,4 @@ function Shell() {
 - `useCLS` relies on layout-shift attribution sources. Entries with no matching source are ignored.
 - By default, descendant attribution is included because the browser often reports the shifted child node rather than the component root.
 - `ignoreRecentInput` defaults to `true` so the value follows Core Web Vitals CLS semantics.
+- The reported value uses CLS session windows rather than summing every matching shift across the whole page view.

--- a/examples/stackblitz/hooks-playground/src/App.tsx
+++ b/examples/stackblitz/hooks-playground/src/App.tsx
@@ -9,6 +9,7 @@ import {UseRenderTrackerDemo} from './demos/useRenderTrackerDemo';
 import {UseThrottledStateDemo} from './demos/useThrottledStateDemo';
 import {UseWebVitalsDemo} from './demos/useWebVitalsDemo';
 import {UseINPDemo} from './demos/useINPDemo';
+import {UseCLSDemo} from './demos/useCLSDemo';
 
 type DemoKey =
   | 'useRenderTracker'
@@ -18,6 +19,7 @@ type DemoKey =
   | 'useMemoProfiling'
   | 'useWebVitals'
   | 'useINP'
+  | 'useCLS'
   | 'useDebouncedState'
   | 'useThrottledState'
   | 'useIntersectionObserver';
@@ -30,6 +32,7 @@ const demos: Record<DemoKey, {label: string; Component: () => JSX.Element}> = {
   useMemoProfiling: {label: 'useMemoProfiling', Component: UseMemoProfilingDemo},
   useWebVitals: {label: 'useWebVitals', Component: UseWebVitalsDemo},
   useINP: {label: 'useINP', Component: UseINPDemo},
+  useCLS: {label: 'useCLS', Component: UseCLSDemo},
   useDebouncedState: {label: 'useDebouncedState', Component: UseDebouncedStateDemo},
   useThrottledState: {label: 'useThrottledState', Component: UseThrottledStateDemo},
   useIntersectionObserver: {label: 'useIntersectionObserver', Component: UseIntersectionObserverDemo},

--- a/examples/stackblitz/hooks-playground/src/demos/useCLSDemo.tsx
+++ b/examples/stackblitz/hooks-playground/src/demos/useCLSDemo.tsx
@@ -1,0 +1,69 @@
+import React, {useState} from 'react';
+import {useCLS} from 'react-perf-hooks';
+
+export function UseCLSDemo() {
+  const [showHero, setShowHero] = useState(false);
+  const [showNotice, setShowNotice] = useState(false);
+  const {ref, value, rating, entries, isSupported} = useCLS<HTMLDivElement>({
+    onMetric: (metric) => {
+      console.info('[useCLS demo]', metric);
+    },
+  });
+
+  return (
+    <section style={{fontFamily: 'system-ui, sans-serif', maxWidth: 640, margin: '0 auto'}}>
+      <h2>useCLS demo</h2>
+      <p>Toggle delayed content inside the observed card to see component-level layout shift attribution.</p>
+
+      <div style={{display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 16}}>
+        <button type="button" onClick={() => setShowHero((current) => !current)}>
+          Toggle unreserved media
+        </button>
+        <button type="button" onClick={() => setShowNotice((current) => !current)}>
+          Toggle notice
+        </button>
+      </div>
+
+      <div
+        ref={ref}
+        style={{
+          border: '1px solid #cbd5e1',
+          borderRadius: 8,
+          padding: 16,
+          background: '#ffffff',
+          boxShadow: '0 1px 3px rgba(15, 23, 42, 0.12)',
+        }}
+      >
+        <h3 style={{marginTop: 0}}>Observed product card</h3>
+        {showHero ? (
+          <div
+            style={{
+              height: 140,
+              marginBottom: 12,
+              background: 'linear-gradient(135deg, #0f766e, #2563eb)',
+              borderRadius: 6,
+            }}
+          />
+        ) : null}
+        <p style={{margin: '0 0 12px'}}>
+          This card intentionally inserts content without reserving space so supported browsers can emit
+          layout-shift entries.
+        </p>
+        {showNotice ? (
+          <p style={{margin: '0 0 12px', padding: 10, background: '#fef3c7', borderRadius: 6}}>
+            Dynamic notice loaded after initial content.
+          </p>
+        ) : null}
+        <strong>Component CLS:</strong>{' '}
+        {isSupported ? `${value.toFixed(3)} (${rating ?? 'waiting'})` : 'layout-shift unsupported'}
+      </div>
+
+      <dl>
+        <dt>Matching entries</dt>
+        <dd>{entries.length}</dd>
+        <dt>Latest delta</dt>
+        <dd>{entries.at(-1)?.delta.toFixed(3) ?? 'waiting'}</dd>
+      </dl>
+    </section>
+  );
+}

--- a/src/hooks/useCLS/index.ts
+++ b/src/hooks/useCLS/index.ts
@@ -1,0 +1,259 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type CLSRating = 'good' | 'needs-improvement' | 'poor';
+
+export interface CLSAttribution {
+  /** The shifted node reported by the browser, when available. */
+  node: Node | null;
+  /** Node position before the shift. */
+  previousRect: DOMRectReadOnly | null;
+  /** Node position after the shift. */
+  currentRect: DOMRectReadOnly | null;
+}
+
+export interface CLSMetric {
+  /** Always `CLS` for easy analytics payloads. */
+  name: 'CLS';
+  /** Cumulative Layout Shift score accumulated for the observed element. */
+  value: number;
+  /** Delta contributed by the latest matching layout-shift entry. */
+  delta: number;
+  /** Google's CLS rating thresholds: good < 0.1, poor > 0.25. */
+  rating: CLSRating;
+  /** Absolute layout-shift start time in milliseconds from navigation start. */
+  startTime: number;
+  /** Whether the shift happened shortly after user input. */
+  hadRecentInput: boolean;
+  /** Attribution sources that matched the observed element. */
+  sources: CLSAttribution[];
+  /** Time when this hook converted the browser entry into state. */
+  timestamp: number;
+}
+
+export interface UseCLSOptions {
+  /**
+   * Called whenever a matching layout shift changes the component CLS value.
+   * Use this for analytics or dev overlays.
+   */
+  onMetric?: (metric: CLSMetric) => void;
+  /**
+   * Include shifts from descendants of the observed element.
+   * Defaults to `true`.
+   */
+  includeDescendants?: boolean;
+  /**
+   * Ignore layout shifts that happened shortly after user input, matching
+   * Core Web Vitals CLS behavior. Defaults to `true`.
+   */
+  ignoreRecentInput?: boolean;
+  /**
+   * Maximum number of matching layout-shift metrics retained in state.
+   * Defaults to `50`.
+   */
+  maxEntries?: number;
+  /**
+   * Set to `false` to disable the observer entirely.
+   * Defaults to `true`.
+   */
+  enabled?: boolean;
+}
+
+export interface UseCLSReturn<T extends Element = HTMLElement> {
+  /** Attach this ref to the component root you want to inspect. */
+  ref: (node: T | null) => void;
+  /** Latest cumulative CLS metric for the observed element. */
+  metric: CLSMetric | null;
+  /** Convenience value from `metric.value`. */
+  value: number;
+  /** Convenience value from `metric.rating`. */
+  rating: CLSRating | null;
+  /** Matching layout-shift metrics retained for debugging. */
+  entries: CLSMetric[];
+  /** Whether this browser can observe Layout Instability entries. */
+  isSupported: boolean;
+}
+
+interface LayoutShiftAttributionLike {
+  node?: Node | null;
+  previousRect?: DOMRectReadOnly;
+  currentRect?: DOMRectReadOnly;
+}
+
+interface LayoutShiftEntryLike extends PerformanceEntry {
+  value?: number;
+  hadRecentInput?: boolean;
+  sources?: LayoutShiftAttributionLike[];
+}
+
+interface PerformanceObserverEntryListLike {
+  getEntries: () => PerformanceEntry[];
+}
+
+type PerformanceObserverCallbackLike = (list: PerformanceObserverEntryListLike, observer: PerformanceObserver) => void;
+
+type PerformanceObserverConstructorLike = {
+  new (callback: PerformanceObserverCallbackLike): PerformanceObserver;
+  supportedEntryTypes?: readonly string[];
+};
+
+const DEFAULT_MAX_ENTRIES = 50;
+const CLS_GOOD_THRESHOLD = 0.1;
+const CLS_POOR_THRESHOLD = 0.25;
+
+function getCLSRating(value: number): CLSRating {
+  if (value < CLS_GOOD_THRESHOLD) return 'good';
+  if (value <= CLS_POOR_THRESHOLD) return 'needs-improvement';
+  return 'poor';
+}
+
+function getNow(): number {
+  return typeof performance !== 'undefined' && typeof performance.now === 'function' ? performance.now() : Date.now();
+}
+
+function supportsLayoutShift(): boolean {
+  if (typeof window === 'undefined' || typeof PerformanceObserver === 'undefined') {
+    return false;
+  }
+
+  const Observer = PerformanceObserver as PerformanceObserverConstructorLike;
+  return Array.isArray(Observer.supportedEntryTypes) && Observer.supportedEntryTypes.includes('layout-shift');
+}
+
+function sourceMatchesTarget(
+  source: LayoutShiftAttributionLike,
+  target: Element,
+  includeDescendants: boolean
+): boolean {
+  if (!source.node) return false;
+  if (source.node === target) return true;
+
+  return includeDescendants && target.contains(source.node);
+}
+
+function getMatchingSources(
+  entry: LayoutShiftEntryLike,
+  target: Element,
+  includeDescendants: boolean
+): CLSAttribution[] {
+  return (entry.sources ?? [])
+    .filter((source) => sourceMatchesTarget(source, target, includeDescendants))
+    .map((source) => ({
+      node: source.node ?? null,
+      previousRect: source.previousRect ?? null,
+      currentRect: source.currentRect ?? null,
+    }));
+}
+
+function createCLSMetric(
+  entry: LayoutShiftEntryLike,
+  value: number,
+  cumulativeValue: number,
+  sources: CLSAttribution[]
+): CLSMetric {
+  return {
+    name: 'CLS',
+    value: cumulativeValue,
+    delta: value,
+    rating: getCLSRating(cumulativeValue),
+    startTime: entry.startTime,
+    hadRecentInput: Boolean(entry.hadRecentInput),
+    sources,
+    timestamp: getNow(),
+  };
+}
+
+/**
+ * Tracks Cumulative Layout Shift (CLS) for a specific component root.
+ * Attach the returned `ref` to the element you want to inspect; the hook
+ * accumulates layout-shift entries attributed to that node or its descendants.
+ *
+ * @example
+ * function ProductCard() {
+ *   const { ref, value, rating } = useCLS<HTMLDivElement>();
+ *
+ *   return (
+ *     <div ref={ref}>
+ *       CLS: {value.toFixed(3)} {rating}
+ *     </div>
+ *   );
+ * }
+ */
+export function useCLS<T extends Element = HTMLElement>(options: UseCLSOptions = {}): UseCLSReturn<T> {
+  const {
+    onMetric,
+    includeDescendants = true,
+    ignoreRecentInput = true,
+    maxEntries = DEFAULT_MAX_ENTRIES,
+    enabled = true,
+  } = options;
+  const [target, setTarget] = useState<T | null>(null);
+  const [metric, setMetric] = useState<CLSMetric | null>(null);
+  const [entries, setEntries] = useState<CLSMetric[]>([]);
+  const cumulativeValueRef = useRef(0);
+  const targetRef = useRef<T | null>(null);
+  const onMetricRef = useRef(onMetric);
+  const isSupported = supportsLayoutShift();
+
+  useEffect(() => {
+    onMetricRef.current = onMetric;
+  }, [onMetric]);
+
+  const ref = useCallback((node: T | null) => {
+    if (node !== targetRef.current) {
+      targetRef.current = node;
+      cumulativeValueRef.current = 0;
+      setMetric(null);
+      setEntries([]);
+    }
+
+    setTarget(node);
+  }, []);
+
+  const updateMetric = useCallback(
+    (entry: LayoutShiftEntryLike, matchingSources: CLSAttribution[]) => {
+      const shiftValue = typeof entry.value === 'number' ? entry.value : 0;
+      if (shiftValue <= 0) return;
+
+      cumulativeValueRef.current += shiftValue;
+      const nextMetric = createCLSMetric(entry, shiftValue, cumulativeValueRef.current, matchingSources);
+
+      setMetric(nextMetric);
+      setEntries((previous) => [...previous, nextMetric].slice(-maxEntries));
+      onMetricRef.current?.(nextMetric);
+    },
+    [maxEntries]
+  );
+
+  useEffect(() => {
+    if (!enabled || !isSupported || !target) return;
+
+    const Observer = PerformanceObserver as PerformanceObserverConstructorLike;
+    const observer = new Observer((list) => {
+      for (const entry of list.getEntries()) {
+        const layoutShiftEntry = entry as LayoutShiftEntryLike;
+        if (ignoreRecentInput && layoutShiftEntry.hadRecentInput) continue;
+
+        const matchingSources = getMatchingSources(layoutShiftEntry, target, includeDescendants);
+        if (matchingSources.length === 0) continue;
+
+        updateMetric(layoutShiftEntry, matchingSources);
+      }
+    });
+
+    observer.observe({
+      type: 'layout-shift',
+      buffered: true,
+    });
+
+    return () => observer.disconnect();
+  }, [enabled, ignoreRecentInput, includeDescendants, isSupported, target, updateMetric]);
+
+  return {
+    ref,
+    metric,
+    value: metric?.value ?? 0,
+    rating: metric?.rating ?? null,
+    entries,
+    isSupported,
+  };
+}

--- a/src/hooks/useCLS/index.ts
+++ b/src/hooks/useCLS/index.ts
@@ -251,37 +251,34 @@ export function useCLS<T extends Element = HTMLElement>(options: UseCLSOptions =
     setTarget(node);
   }, []);
 
-  const updateMetric = useCallback(
-    (entry: LayoutShiftEntryLike, matchingSources: CLSAttribution[]) => {
-      const shiftValue = typeof entry.value === 'number' ? entry.value : 0;
-      if (shiftValue <= 0) return;
+  const updateMetric = useCallback((entry: LayoutShiftEntryLike, matchingSources: CLSAttribution[]) => {
+    const shiftValue = typeof entry.value === 'number' ? entry.value : 0;
+    if (shiftValue <= 0) return;
 
-      const isSameSession =
-        sessionValueRef.current > 0 &&
-        entry.startTime - sessionLastEntryTimeRef.current < CLS_SESSION_GAP_LIMIT &&
-        entry.startTime - sessionStartTimeRef.current < CLS_SESSION_WINDOW_LIMIT;
+    const isSameSession =
+      sessionValueRef.current > 0 &&
+      entry.startTime - sessionLastEntryTimeRef.current < CLS_SESSION_GAP_LIMIT &&
+      entry.startTime - sessionStartTimeRef.current < CLS_SESSION_WINDOW_LIMIT;
 
-      if (isSameSession) {
-        sessionValueRef.current += shiftValue;
-      } else {
-        sessionValueRef.current = shiftValue;
-        sessionStartTimeRef.current = entry.startTime;
-      }
+    if (isSameSession) {
+      sessionValueRef.current += shiftValue;
+    } else {
+      sessionValueRef.current = shiftValue;
+      sessionStartTimeRef.current = entry.startTime;
+    }
 
-      sessionLastEntryTimeRef.current = entry.startTime;
+    sessionLastEntryTimeRef.current = entry.startTime;
 
-      const previousValue = currentValueRef.current;
-      currentValueRef.current = Math.max(currentValueRef.current, sessionValueRef.current);
-      const nextMetric = createCLSMetric(entry, shiftValue, currentValueRef.current, matchingSources);
+    const previousValue = currentValueRef.current;
+    currentValueRef.current = Math.max(currentValueRef.current, sessionValueRef.current);
+    const nextMetric = createCLSMetric(entry, shiftValue, currentValueRef.current, matchingSources);
 
-      setMetric(nextMetric);
-      setEntries((previous) => [...previous, nextMetric].slice(-maxEntriesRef.current));
-      if (currentValueRef.current > previousValue) {
-        onMetricRef.current?.(nextMetric);
-      }
-    },
-    []
-  );
+    setMetric(nextMetric);
+    setEntries((previous) => [...previous, nextMetric].slice(-maxEntriesRef.current));
+    if (currentValueRef.current > previousValue) {
+      onMetricRef.current?.(nextMetric);
+    }
+  }, []);
 
   useEffect(() => {
     if (!enabled || !isSupported || !target) return;

--- a/src/hooks/useCLS/index.ts
+++ b/src/hooks/useCLS/index.ts
@@ -14,7 +14,7 @@ export interface CLSAttribution {
 export interface CLSMetric {
   /** Always `CLS` for easy analytics payloads. */
   name: 'CLS';
-  /** Cumulative Layout Shift score accumulated for the observed element. */
+  /** Largest CLS session-window score for the observed element. */
   value: number;
   /** Delta contributed by the latest matching layout-shift entry. */
   delta: number;
@@ -61,7 +61,7 @@ export interface UseCLSOptions {
 export interface UseCLSReturn<T extends Element = HTMLElement> {
   /** Attach this ref to the component root you want to inspect. */
   ref: (node: T | null) => void;
-  /** Latest cumulative CLS metric for the observed element. */
+  /** Latest CLS metric for the observed element, scored by largest session window. */
   metric: CLSMetric | null;
   /** Convenience value from `metric.value`. */
   value: number;
@@ -99,6 +99,8 @@ type PerformanceObserverConstructorLike = {
 const DEFAULT_MAX_ENTRIES = 50;
 const CLS_GOOD_THRESHOLD = 0.1;
 const CLS_POOR_THRESHOLD = 0.25;
+const CLS_SESSION_GAP_LIMIT = 1000;
+const CLS_SESSION_WINDOW_LIMIT = 5000;
 
 function getCLSRating(value: number): CLSRating {
   if (value < CLS_GOOD_THRESHOLD) return 'good';
@@ -162,10 +164,27 @@ function createCLSMetric(
   };
 }
 
+function getRectKey(rect?: DOMRectReadOnly): string {
+  if (!rect) return '';
+
+  return `${rect.x}:${rect.y}:${rect.width}:${rect.height}`;
+}
+
+function getLayoutShiftEntryKey(entry: LayoutShiftEntryLike): string {
+  const sourceKeys = (entry.sources ?? [])
+    .map((source) => {
+      const nodeName = source.node instanceof Element ? source.node.tagName : source.node?.nodeName;
+      return `${nodeName ?? 'unknown'}:${getRectKey(source.previousRect)}:${getRectKey(source.currentRect)}`;
+    })
+    .join('|');
+
+  return `${entry.startTime}:${entry.value ?? 0}:${Boolean(entry.hadRecentInput)}:${sourceKeys}`;
+}
+
 /**
  * Tracks Cumulative Layout Shift (CLS) for a specific component root.
  * Attach the returned `ref` to the element you want to inspect; the hook
- * accumulates layout-shift entries attributed to that node or its descendants.
+ * reports the largest CLS session window attributed to that node or its descendants.
  *
  * @example
  * function ProductCard() {
@@ -189,19 +208,42 @@ export function useCLS<T extends Element = HTMLElement>(options: UseCLSOptions =
   const [target, setTarget] = useState<T | null>(null);
   const [metric, setMetric] = useState<CLSMetric | null>(null);
   const [entries, setEntries] = useState<CLSMetric[]>([]);
-  const cumulativeValueRef = useRef(0);
+  const currentValueRef = useRef(0);
+  const sessionValueRef = useRef(0);
+  const sessionStartTimeRef = useRef(0);
+  const sessionLastEntryTimeRef = useRef(0);
+  const processedEntryKeysRef = useRef<Set<string>>(new Set());
   const targetRef = useRef<T | null>(null);
   const onMetricRef = useRef(onMetric);
+  const includeDescendantsRef = useRef(includeDescendants);
+  const ignoreRecentInputRef = useRef(ignoreRecentInput);
+  const maxEntriesRef = useRef(maxEntries);
   const isSupported = supportsLayoutShift();
 
   useEffect(() => {
     onMetricRef.current = onMetric;
   }, [onMetric]);
 
+  useEffect(() => {
+    includeDescendantsRef.current = includeDescendants;
+  }, [includeDescendants]);
+
+  useEffect(() => {
+    ignoreRecentInputRef.current = ignoreRecentInput;
+  }, [ignoreRecentInput]);
+
+  useEffect(() => {
+    maxEntriesRef.current = maxEntries;
+  }, [maxEntries]);
+
   const ref = useCallback((node: T | null) => {
     if (node !== targetRef.current) {
       targetRef.current = node;
-      cumulativeValueRef.current = 0;
+      currentValueRef.current = 0;
+      sessionValueRef.current = 0;
+      sessionStartTimeRef.current = 0;
+      sessionLastEntryTimeRef.current = 0;
+      processedEntryKeysRef.current.clear();
       setMetric(null);
       setEntries([]);
     }
@@ -214,14 +256,31 @@ export function useCLS<T extends Element = HTMLElement>(options: UseCLSOptions =
       const shiftValue = typeof entry.value === 'number' ? entry.value : 0;
       if (shiftValue <= 0) return;
 
-      cumulativeValueRef.current += shiftValue;
-      const nextMetric = createCLSMetric(entry, shiftValue, cumulativeValueRef.current, matchingSources);
+      const isSameSession =
+        sessionValueRef.current > 0 &&
+        entry.startTime - sessionLastEntryTimeRef.current < CLS_SESSION_GAP_LIMIT &&
+        entry.startTime - sessionStartTimeRef.current < CLS_SESSION_WINDOW_LIMIT;
+
+      if (isSameSession) {
+        sessionValueRef.current += shiftValue;
+      } else {
+        sessionValueRef.current = shiftValue;
+        sessionStartTimeRef.current = entry.startTime;
+      }
+
+      sessionLastEntryTimeRef.current = entry.startTime;
+
+      const previousValue = currentValueRef.current;
+      currentValueRef.current = Math.max(currentValueRef.current, sessionValueRef.current);
+      const nextMetric = createCLSMetric(entry, shiftValue, currentValueRef.current, matchingSources);
 
       setMetric(nextMetric);
-      setEntries((previous) => [...previous, nextMetric].slice(-maxEntries));
-      onMetricRef.current?.(nextMetric);
+      setEntries((previous) => [...previous, nextMetric].slice(-maxEntriesRef.current));
+      if (currentValueRef.current > previousValue) {
+        onMetricRef.current?.(nextMetric);
+      }
     },
-    [maxEntries]
+    []
   );
 
   useEffect(() => {
@@ -231,11 +290,15 @@ export function useCLS<T extends Element = HTMLElement>(options: UseCLSOptions =
     const observer = new Observer((list) => {
       for (const entry of list.getEntries()) {
         const layoutShiftEntry = entry as LayoutShiftEntryLike;
-        if (ignoreRecentInput && layoutShiftEntry.hadRecentInput) continue;
+        const entryKey = getLayoutShiftEntryKey(layoutShiftEntry);
+        if (processedEntryKeysRef.current.has(entryKey)) continue;
 
-        const matchingSources = getMatchingSources(layoutShiftEntry, target, includeDescendants);
+        if (ignoreRecentInputRef.current && layoutShiftEntry.hadRecentInput) continue;
+
+        const matchingSources = getMatchingSources(layoutShiftEntry, target, includeDescendantsRef.current);
         if (matchingSources.length === 0) continue;
 
+        processedEntryKeysRef.current.add(entryKey);
         updateMetric(layoutShiftEntry, matchingSources);
       }
     });
@@ -246,7 +309,7 @@ export function useCLS<T extends Element = HTMLElement>(options: UseCLSOptions =
     });
 
     return () => observer.disconnect();
-  }, [enabled, ignoreRecentInput, includeDescendants, isSupported, target, updateMetric]);
+  }, [enabled, isSupported, target, updateMetric]);
 
   return {
     ref,

--- a/src/hooks/useCLS/useCLS.test.tsx
+++ b/src/hooks/useCLS/useCLS.test.tsx
@@ -1,0 +1,271 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCLS } from './index';
+
+type ObserverCallback = (list: { getEntries: () => PerformanceEntry[] }, observer: PerformanceObserver) => void;
+
+const originalPerformanceObserver = globalThis.PerformanceObserver;
+
+class MockPerformanceObserver {
+  static supportedEntryTypes = ['layout-shift'];
+  static callback: ObserverCallback | null = null;
+  static observe = vi.fn();
+  static disconnect = vi.fn();
+
+  constructor(callback: ObserverCallback) {
+    MockPerformanceObserver.callback = callback;
+  }
+
+  observe(options: PerformanceObserverInit): void {
+    MockPerformanceObserver.observe(options);
+  }
+
+  disconnect(): void {
+    MockPerformanceObserver.disconnect();
+  }
+}
+
+function setMockPerformanceObserver(entryTypes: string[] = ['layout-shift']): void {
+  MockPerformanceObserver.supportedEntryTypes = entryTypes;
+  globalThis.PerformanceObserver = MockPerformanceObserver as unknown as typeof PerformanceObserver;
+}
+
+function attachRef<T extends Element>(ref: (node: T | null) => void, node: T): void {
+  act(() => {
+    ref(node);
+  });
+}
+
+function emitEntry(
+  entry: Partial<PerformanceEntry> & { value?: number; hadRecentInput?: boolean; sources?: unknown[] }
+): void {
+  act(() => {
+    MockPerformanceObserver.callback?.(
+      {
+        getEntries: () => [entry as PerformanceEntry],
+      },
+      {} as PerformanceObserver
+    );
+  });
+}
+
+describe('useCLS', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    MockPerformanceObserver.callback = null;
+    setMockPerformanceObserver();
+  });
+
+  afterEach(() => {
+    globalThis.PerformanceObserver = originalPerformanceObserver;
+  });
+
+  it('returns initial component CLS state before the ref is attached', () => {
+    const { result } = renderHook(() => useCLS());
+
+    expect(result.current.metric).toBeNull();
+    expect(result.current.value).toBe(0);
+    expect(result.current.rating).toBeNull();
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.isSupported).toBe(true);
+    expect(MockPerformanceObserver.observe).not.toHaveBeenCalled();
+  });
+
+  it('observes buffered layout-shift entries after the ref is attached', () => {
+    const target = document.createElement('div');
+    const { result } = renderHook(() => useCLS<HTMLDivElement>());
+
+    attachRef(result.current.ref, target);
+
+    expect(MockPerformanceObserver.observe).toHaveBeenCalledWith({
+      type: 'layout-shift',
+      buffered: true,
+    });
+  });
+
+  it('accumulates CLS for the observed element', () => {
+    const target = document.createElement('div');
+    const { result } = renderHook(() => useCLS<HTMLDivElement>());
+    attachRef(result.current.ref, target);
+
+    emitEntry({
+      name: 'layout-shift',
+      value: 0.04,
+      startTime: 120,
+      hadRecentInput: false,
+      sources: [{ node: target }],
+    });
+    emitEntry({
+      name: 'layout-shift',
+      value: 0.06,
+      startTime: 180,
+      hadRecentInput: false,
+      sources: [{ node: target }],
+    });
+
+    expect(result.current.metric).toMatchObject({
+      name: 'CLS',
+      value: 0.1,
+      delta: 0.06,
+      rating: 'needs-improvement',
+      startTime: 180,
+      hadRecentInput: false,
+    });
+    expect(result.current.value).toBe(0.1);
+    expect(result.current.entries).toHaveLength(2);
+  });
+
+  it('tracks layout shifts attributed to descendants by default', () => {
+    const target = document.createElement('section');
+    const child = document.createElement('img');
+    target.appendChild(child);
+    const { result } = renderHook(() => useCLS<HTMLElement>());
+    attachRef(result.current.ref, target);
+
+    emitEntry({
+      value: 0.08,
+      startTime: 20,
+      hadRecentInput: false,
+      sources: [{ node: child }],
+    });
+
+    expect(result.current.value).toBe(0.08);
+    expect(result.current.metric?.sources[0]?.node).toBe(child);
+  });
+
+  it('can ignore descendant shifts when includeDescendants=false', () => {
+    const target = document.createElement('section');
+    const child = document.createElement('img');
+    target.appendChild(child);
+    const { result } = renderHook(() => useCLS<HTMLElement>({ includeDescendants: false }));
+    attachRef(result.current.ref, target);
+
+    emitEntry({
+      value: 0.08,
+      startTime: 20,
+      hadRecentInput: false,
+      sources: [{ node: child }],
+    });
+    emitEntry({
+      value: 0.05,
+      startTime: 30,
+      hadRecentInput: false,
+      sources: [{ node: target }],
+    });
+
+    expect(result.current.value).toBe(0.05);
+    expect(result.current.entries).toHaveLength(1);
+  });
+
+  it('ignores layout shifts caused by recent input by default', () => {
+    const target = document.createElement('div');
+    const onMetric = vi.fn();
+    const { result } = renderHook(() => useCLS<HTMLDivElement>({ onMetric }));
+    attachRef(result.current.ref, target);
+
+    emitEntry({
+      value: 0.2,
+      startTime: 10,
+      hadRecentInput: true,
+      sources: [{ node: target }],
+    });
+
+    expect(result.current.metric).toBeNull();
+    expect(onMetric).not.toHaveBeenCalled();
+  });
+
+  it('can include layout shifts caused by recent input', () => {
+    const target = document.createElement('div');
+    const { result } = renderHook(() => useCLS<HTMLDivElement>({ ignoreRecentInput: false }));
+    attachRef(result.current.ref, target);
+
+    emitEntry({
+      value: 0.2,
+      startTime: 10,
+      hadRecentInput: true,
+      sources: [{ node: target }],
+    });
+
+    expect(result.current.metric).toMatchObject({
+      value: 0.2,
+      rating: 'needs-improvement',
+      hadRecentInput: true,
+    });
+  });
+
+  it('calls onMetric with the cumulative component CLS metric', () => {
+    const target = document.createElement('div');
+    const onMetric = vi.fn();
+    const { result } = renderHook(() => useCLS<HTMLDivElement>({ onMetric }));
+    attachRef(result.current.ref, target);
+
+    emitEntry({ value: 0.12, startTime: 1, hadRecentInput: false, sources: [{ node: target }] });
+    emitEntry({ value: 0.14, startTime: 2, hadRecentInput: false, sources: [{ node: target }] });
+
+    expect(onMetric).toHaveBeenCalledTimes(2);
+    expect(onMetric).toHaveBeenLastCalledWith(expect.objectContaining({ value: 0.26, rating: 'poor' }));
+  });
+
+  it('limits retained entries with maxEntries', () => {
+    const target = document.createElement('div');
+    const { result } = renderHook(() => useCLS<HTMLDivElement>({ maxEntries: 2 }));
+    attachRef(result.current.ref, target);
+
+    emitEntry({ value: 0.01, startTime: 1, hadRecentInput: false, sources: [{ node: target }] });
+    emitEntry({ value: 0.02, startTime: 2, hadRecentInput: false, sources: [{ node: target }] });
+    emitEntry({ value: 0.03, startTime: 3, hadRecentInput: false, sources: [{ node: target }] });
+
+    expect(result.current.entries).toHaveLength(2);
+    expect(result.current.entries.map((entry) => entry.delta)).toEqual([0.02, 0.03]);
+  });
+
+  it('resets metrics when the observed node changes', () => {
+    const firstTarget = document.createElement('div');
+    const secondTarget = document.createElement('div');
+    const { result } = renderHook(() => useCLS<HTMLDivElement>());
+    attachRef(result.current.ref, firstTarget);
+
+    emitEntry({ value: 0.12, startTime: 1, hadRecentInput: false, sources: [{ node: firstTarget }] });
+
+    expect(result.current.value).toBe(0.12);
+
+    attachRef(result.current.ref, secondTarget);
+
+    expect(result.current.metric).toBeNull();
+    expect(result.current.value).toBe(0);
+    expect(result.current.entries).toEqual([]);
+
+    emitEntry({ value: 0.04, startTime: 2, hadRecentInput: false, sources: [{ node: secondTarget }] });
+
+    expect(result.current.value).toBe(0.04);
+  });
+
+  it('does not subscribe when enabled=false', () => {
+    const target = document.createElement('div');
+    const { result } = renderHook(() => useCLS<HTMLDivElement>({ enabled: false }));
+    attachRef(result.current.ref, target);
+
+    expect(result.current.isSupported).toBe(true);
+    expect(MockPerformanceObserver.observe).not.toHaveBeenCalled();
+  });
+
+  it('returns unsupported state when layout-shift entries are unavailable', () => {
+    setMockPerformanceObserver(['paint']);
+    const target = document.createElement('div');
+    const { result } = renderHook(() => useCLS<HTMLDivElement>());
+    attachRef(result.current.ref, target);
+
+    expect(result.current.isSupported).toBe(false);
+    expect(MockPerformanceObserver.observe).not.toHaveBeenCalled();
+  });
+
+  it('disconnects the observer on unmount', () => {
+    const target = document.createElement('div');
+    const { result, unmount } = renderHook(() => useCLS<HTMLDivElement>());
+    attachRef(result.current.ref, target);
+
+    unmount();
+
+    expect(MockPerformanceObserver.disconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useCLS/useCLS.test.tsx
+++ b/src/hooks/useCLS/useCLS.test.tsx
@@ -83,7 +83,7 @@ describe('useCLS', () => {
     });
   });
 
-  it('accumulates CLS for the observed element', () => {
+  it('accumulates CLS inside one session window for the observed element', () => {
     const target = document.createElement('div');
     const { result } = renderHook(() => useCLS<HTMLDivElement>());
     attachRef(result.current.ref, target);
@@ -113,6 +113,64 @@ describe('useCLS', () => {
     });
     expect(result.current.value).toBe(0.1);
     expect(result.current.entries).toHaveLength(2);
+  });
+
+  it('reports the largest CLS session window instead of a lifetime sum', () => {
+    const target = document.createElement('div');
+    const onMetric = vi.fn();
+    const { result } = renderHook(() => useCLS<HTMLDivElement>({ onMetric }));
+    attachRef(result.current.ref, target);
+
+    emitEntry({
+      name: 'layout-shift',
+      value: 0.08,
+      startTime: 100,
+      hadRecentInput: false,
+      sources: [{ node: target }],
+    });
+    emitEntry({
+      name: 'layout-shift',
+      value: 0.07,
+      startTime: 2200,
+      hadRecentInput: false,
+      sources: [{ node: target }],
+    });
+    emitEntry({
+      name: 'layout-shift',
+      value: 0.06,
+      startTime: 2600,
+      hadRecentInput: false,
+      sources: [{ node: target }],
+    });
+
+    expect(result.current.metric).toMatchObject({
+      value: 0.13,
+      delta: 0.06,
+      rating: 'needs-improvement',
+      startTime: 2600,
+    });
+    expect(result.current.value).toBe(0.13);
+    expect(result.current.entries.map((entry) => entry.value)).toEqual([0.08, 0.08, 0.13]);
+    expect(onMetric).toHaveBeenCalledTimes(2);
+    expect(onMetric).toHaveBeenLastCalledWith(expect.objectContaining({ value: 0.13 }));
+  });
+
+  it('starts a new CLS session after a five second window', () => {
+    const target = document.createElement('div');
+    const { result } = renderHook(() => useCLS<HTMLDivElement>());
+    attachRef(result.current.ref, target);
+
+    emitEntry({ value: 0.04, startTime: 100, hadRecentInput: false, sources: [{ node: target }] });
+    emitEntry({ value: 0.05, startTime: 900, hadRecentInput: false, sources: [{ node: target }] });
+    emitEntry({ value: 0.06, startTime: 5200, hadRecentInput: false, sources: [{ node: target }] });
+
+    expect(result.current.value).toBe(0.09);
+    expect(result.current.metric).toMatchObject({
+      value: 0.09,
+      delta: 0.06,
+      rating: 'good',
+      startTime: 5200,
+    });
   });
 
   it('tracks layout shifts attributed to descendants by default', () => {
@@ -157,6 +215,41 @@ describe('useCLS', () => {
     expect(result.current.entries).toHaveLength(1);
   });
 
+  it('does not resubscribe or recount buffered entries when options change', () => {
+    const target = document.createElement('div');
+    const onMetric = vi.fn();
+    const entry = {
+      value: 0.08,
+      startTime: 20,
+      hadRecentInput: false,
+      sources: [{ node: target }],
+    };
+    const { result, rerender } = renderHook(
+      ({ maxEntries, includeDescendants }) =>
+        useCLS<HTMLDivElement>({
+          maxEntries,
+          includeDescendants,
+          onMetric,
+        }),
+      {
+        initialProps: {
+          maxEntries: 50,
+          includeDescendants: true,
+        },
+      }
+    );
+    attachRef(result.current.ref, target);
+
+    emitEntry(entry);
+    rerender({ maxEntries: 2, includeDescendants: false });
+    emitEntry(entry);
+
+    expect(MockPerformanceObserver.observe).toHaveBeenCalledTimes(1);
+    expect(result.current.value).toBe(0.08);
+    expect(result.current.entries).toHaveLength(1);
+    expect(onMetric).toHaveBeenCalledTimes(1);
+  });
+
   it('ignores layout shifts caused by recent input by default', () => {
     const target = document.createElement('div');
     const onMetric = vi.fn();
@@ -193,7 +286,7 @@ describe('useCLS', () => {
     });
   });
 
-  it('calls onMetric with the cumulative component CLS metric', () => {
+  it('calls onMetric when the largest component CLS session value changes', () => {
     const target = document.createElement('div');
     const onMetric = vi.fn();
     const { result } = renderHook(() => useCLS<HTMLDivElement>({ onMetric }));
@@ -201,6 +294,8 @@ describe('useCLS', () => {
 
     emitEntry({ value: 0.12, startTime: 1, hadRecentInput: false, sources: [{ node: target }] });
     emitEntry({ value: 0.14, startTime: 2, hadRecentInput: false, sources: [{ node: target }] });
+
+    emitEntry({ value: 0.1, startTime: 3000, hadRecentInput: false, sources: [{ node: target }] });
 
     expect(onMetric).toHaveBeenCalledTimes(2);
     expect(onMetric).toHaveBeenLastCalledWith(expect.objectContaining({ value: 0.26, rating: 'poor' }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,9 @@ export type { WebVitalMetric, WebVitalsState, UseWebVitalsOptions, VitalRating }
 export { useINP } from './hooks/useINP';
 export type { INPMetric, INPRating, UseINPOptions, UseINPReturn } from './hooks/useINP';
 
+export { useCLS } from './hooks/useCLS';
+export type { CLSAttribution, CLSMetric, CLSRating, UseCLSOptions, UseCLSReturn } from './hooks/useCLS';
+
 export { useDebouncedState } from './hooks/useDebouncedState';
 export type { DebouncedStateStats, UseDebouncedStateReturn } from './hooks/useDebouncedState';
 

--- a/website/docs/hooks/use-cls.mdx
+++ b/website/docs/hooks/use-cls.mdx
@@ -1,0 +1,73 @@
+---
+title: useCLS
+description: Track Cumulative Layout Shift for a specific component root.
+---
+
+import StackBlitzEmbed from '@site/src/components/StackBlitzEmbed';
+
+## Description and use case
+
+`useCLS` tracks Cumulative Layout Shift for one DOM node. Attach the returned `ref` to a component root and the hook accumulates layout-shift entries attributed to that element or its descendants.
+
+This is useful when page-level CLS tells you that something moved, but you need to identify the component that jumped while dynamic content loaded.
+
+## API signature
+
+```ts
+function useCLS<T extends Element = HTMLElement>(options?: UseCLSOptions): UseCLSReturn<T>
+```
+
+## Parameters
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `options.onMetric` | `(metric: CLSMetric) => void` | No | Callback fired whenever a matching layout shift changes the component CLS value. |
+| `options.includeDescendants` | `boolean` | No | Include layout shifts attributed to descendants. Defaults to `true`. |
+| `options.ignoreRecentInput` | `boolean` | No | Ignore shifts shortly after user input. Defaults to `true`. |
+| `options.maxEntries` | `number` | No | Maximum retained matching metrics. Defaults to `50`. |
+| `options.enabled` | `boolean` | No | Set `false` to disable the observer. |
+
+## Return value
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `ref` | `(node: T \| null) => void` | Attach to the component root you want to inspect. |
+| `metric` | `CLSMetric \| null` | Latest cumulative CLS metric for the observed element. |
+| `value` | `number` | Current cumulative CLS value. Starts at `0`. |
+| `rating` | `CLSRating \| null` | `good`, `needs-improvement`, or `poor`. |
+| `entries` | `CLSMetric[]` | Matching layout-shift metrics retained for debugging. |
+| `isSupported` | `boolean` | Whether this browser supports Layout Instability entries. |
+
+## Live interactive demo (StackBlitz)
+
+<StackBlitzEmbed
+  title="useCLS demo"
+  src="https://stackblitz.com/github/valyefimov/react-perf-hooks/tree/main/examples/stackblitz/hooks-playground?file=src/App.tsx&embed=1&view=preview&startScript=dev&demo=useCLS"
+  openHref="https://stackblitz.com/github/valyefimov/react-perf-hooks/tree/main/examples/stackblitz/hooks-playground?file=src/App.tsx&startScript=dev&demo=useCLS"
+/>
+
+## Code example
+
+```tsx
+import {useCLS} from 'react-perf-hooks';
+
+export function ProductCard() {
+  const {ref, value, rating, isSupported} = useCLS<HTMLDivElement>({
+    onMetric: (metric) => {
+      navigator.sendBeacon('/api/component-cls', JSON.stringify(metric));
+    },
+  });
+
+  return (
+    <article ref={ref}>
+      <strong>Component CLS</strong>
+      <span>{isSupported ? `${value.toFixed(3)} (${rating ?? 'waiting'})` : 'unavailable'}</span>
+    </article>
+  );
+}
+```
+
+## Companion article
+
+- [dev.to companion article](https://dev.to/search?q=useCLS)
+- [Medium companion article](https://medium.com/search?q=useCLS)

--- a/website/docs/hooks/use-cls.mdx
+++ b/website/docs/hooks/use-cls.mdx
@@ -7,7 +7,7 @@ import StackBlitzEmbed from '@site/src/components/StackBlitzEmbed';
 
 ## Description and use case
 
-`useCLS` tracks Cumulative Layout Shift for one DOM node. Attach the returned `ref` to a component root and the hook accumulates layout-shift entries attributed to that element or its descendants.
+`useCLS` tracks Cumulative Layout Shift for one DOM node. Attach the returned `ref` to a component root and the hook reports the largest CLS session window for layout-shift entries attributed to that element or its descendants.
 
 This is useful when page-level CLS tells you that something moved, but you need to identify the component that jumped while dynamic content loaded.
 
@@ -32,8 +32,8 @@ function useCLS<T extends Element = HTMLElement>(options?: UseCLSOptions): UseCL
 | Field | Type | Description |
 | --- | --- | --- |
 | `ref` | `(node: T \| null) => void` | Attach to the component root you want to inspect. |
-| `metric` | `CLSMetric \| null` | Latest cumulative CLS metric for the observed element. |
-| `value` | `number` | Current cumulative CLS value. Starts at `0`. |
+| `metric` | `CLSMetric \| null` | Latest CLS metric for the observed element, scored by largest session window. |
+| `value` | `number` | Current largest CLS session-window value. Starts at `0`. |
 | `rating` | `CLSRating \| null` | `good`, `needs-improvement`, or `poor`. |
 | `entries` | `CLSMetric[]` | Matching layout-shift metrics retained for debugging. |
 | `isSupported` | `boolean` | Whether this browser supports Layout Instability entries. |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -15,6 +15,7 @@ const sidebars: SidebarsConfig = {
         'hooks/use-memo-profiling',
         'hooks/use-web-vitals',
         'hooks/use-inp',
+        'hooks/use-cls',
         'hooks/use-debounced-state',
         'hooks/use-throttled-state',
         'hooks/use-intersection-observer',


### PR DESCRIPTION
Add the `useCLS` hook to measure Cumulative Layout Shift for a specific DOM node, including support for descendant attribution, metric callback, and live debugging via entries. Includes documentation, tests, and a demo.