### PR TITLE
Feat: Add useMemoryStatus hook for heap size monitoring  

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ npm install web-vitals
 | `useINP` | Native Interaction to Next Paint tracking with PerformanceObserver event entries | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-inp) |
 | `useCLS` | Component-scoped Cumulative Layout Shift tracking for a specific DOM node | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-cls) |
 | `useLongTasks` | Log main-thread freezes over 50ms and attach them to the current screen | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-long-tasks) |
+| `useMemoryStatus` | Monitor Chromium JavaScript heap usage and flag high memory pressure | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-memory-status) |
 | `useDebouncedState` | Debounced `useState` with render-skip profiling counters | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-debounced-state) |
 | `useThrottledState` | Throttled `useState` with dropped-update profiling counters | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-throttled-state) |
 | `useIntersectionObserver` | Lazy-loading visibility state plus first-visible and total-visible metrics | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-intersection-observer) |
@@ -92,6 +93,7 @@ import {
   useINP,
   useCLS,
   useLongTasks,
+  useMemoryStatus,
   useDebouncedState,
   useThrottledState,
   useIntersectionObserver,
@@ -133,6 +135,9 @@ function App() {
     screen: () => location.pathname,
     onLongTask: (m) => navigator.sendBeacon('/analytics/long-tasks', JSON.stringify(m)),
   });
+
+  // Monitor Chromium heap telemetry and flag high memory pressure
+  const memory = useMemoryStatus({ warningThresholdRatio: 0.8, interval: 5000 });
 
   // Debounce state updates and inspect profiling counters
   const [query, setQuery, stats] = useDebouncedState('', 250);
@@ -181,6 +186,8 @@ import type {
   LongTaskMetric,
   UseLongTasksOptions,
   UseLongTasksReturn,
+  UseMemoryStatusOptions,
+  UseMemoryStatusReturn,
   DebouncedStateStats,
   UseDebouncedStateReturn,
   ThrottledStateStats,

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -30,6 +30,7 @@ import {
   useIntersectionObserver,
   useLongTasks,
   useMemoProfiling,
+  useMemoryStatus,
   usePerformanceMark,
   useRenderBudget,
   useRenderTracker,

--- a/docs/hooks/use-memory-status.mdx
+++ b/docs/hooks/use-memory-status.mdx
@@ -1,0 +1,80 @@
+---
+title: useMemoryStatus
+description: Monitor Chromium JavaScript heap usage from React.
+---
+
+import StackBlitzEmbed from '@site/src/components/StackBlitzEmbed';
+
+## Description and use case
+
+`useMemoryStatus` wraps Chromium's non-standard `performance.memory` API. It polls JavaScript heap telemetry on an interval and flags when used heap crosses a configurable ratio of total allocated heap.
+
+This is useful for heavy dashboards, image editors, virtualized workspaces, and development overlays where memory leaks or garbage collector churn need early visibility.
+
+Browsers that do not expose `performance.memory`, including Safari and Firefox, return an unsupported state without throwing.
+
+## API signature
+
+```ts
+function useMemoryStatus(options?: UseMemoryStatusOptions): UseMemoryStatusReturn;
+```
+
+## Parameters
+
+| Name                            | Type      | Required | Description                                                             |
+| ------------------------------- | --------- | -------- | ----------------------------------------------------------------------- |
+| `options.warningThresholdRatio` | `number`  | No       | Ratio of used heap to total heap that sets `isRiskZone`. Default `0.8`. |
+| `options.interval`              | `number`  | No       | Polling interval in milliseconds. Default `5000`.                       |
+| `options.enabled`               | `boolean` | No       | Set `false` to disable polling.                                         |
+
+## Return value
+
+| Field             | Type             | Description                                                              |
+| ----------------- | ---------------- | ------------------------------------------------------------------------ |
+| `usedJSHeapSize`  | `number \| null` | Current used JavaScript heap size in bytes, or `null` when unsupported.  |
+| `totalJSHeapSize` | `number \| null` | Current total allocated JavaScript heap size in bytes, or `null`.        |
+| `jsHeapSizeLimit` | `number \| null` | Browser JavaScript heap size limit in bytes, or `null`.                  |
+| `memoryLimit`     | `number \| null` | Alias for `jsHeapSizeLimit`.                                             |
+| `isRiskZone`      | `boolean`        | Whether `usedJSHeapSize / totalJSHeapSize` reached the configured ratio. |
+| `isSupported`     | `boolean`        | Whether this browser exposes `performance.memory`.                       |
+
+## Live interactive demo (StackBlitz)
+
+<StackBlitzEmbed
+  title="useMemoryStatus demo"
+  src="https://stackblitz.com/github/valyefimov/react-perf-hooks/tree/main/examples/stackblitz/hooks-playground?file=src/App.tsx&embed=1&view=preview&startScript=dev&demo=useMemoryStatus"
+  openHref="https://stackblitz.com/github/valyefimov/react-perf-hooks/tree/main/examples/stackblitz/hooks-playground?file=src/App.tsx&startScript=dev&demo=useMemoryStatus"
+/>
+
+## Code example
+
+```tsx
+import { useMemoryStatus } from 'react-perf-hooks';
+
+export function MemoryStatusBadge() {
+  const { usedJSHeapSize, totalJSHeapSize, memoryLimit, isRiskZone, isSupported } = useMemoryStatus(
+    {
+      warningThresholdRatio: 0.8,
+      interval: 5000,
+    },
+  );
+
+  if (!isSupported) {
+    return <p>Memory telemetry is not available in this browser.</p>;
+  }
+
+  return (
+    <p>
+      Heap: {formatBytes(usedJSHeapSize)} / {formatBytes(totalJSHeapSize)} used, limit{' '}
+      {formatBytes(memoryLimit)}
+      {isRiskZone ? ' (risk zone)' : ''}
+    </p>
+  );
+}
+
+function formatBytes(value: number | null) {
+  if (value === null) return 'n/a';
+
+  return `${(value / 1024 / 1024).toFixed(1)} MB`;
+}
+```

--- a/examples/stackblitz/hooks-playground/src/App.tsx
+++ b/examples/stackblitz/hooks-playground/src/App.tsx
@@ -7,6 +7,7 @@ import { UseINPDemo } from './demos/useINPDemo';
 import { UseIntersectionObserverDemo } from './demos/useIntersectionObserverDemo';
 import { UseLongTasksDemo } from './demos/useLongTasksDemo';
 import { UseMemoProfilingDemo } from './demos/useMemoProfilingDemo';
+import { UseMemoryStatusDemo } from './demos/useMemoryStatusDemo';
 import { UsePerformanceMarkDemo } from './demos/usePerformanceMarkDemo';
 import { UseRenderBudgetDemo } from './demos/useRenderBudgetDemo';
 import { UseRenderTrackerDemo } from './demos/useRenderTrackerDemo';
@@ -23,6 +24,7 @@ type DemoKey =
   | 'useINP'
   | 'useCLS'
   | 'useLongTasks'
+  | 'useMemoryStatus'
   | 'useFps'
   | 'useDebouncedState'
   | 'useThrottledState'
@@ -38,6 +40,7 @@ const demos: Record<DemoKey, { label: string; Component: () => JSX.Element }> = 
   useINP: { label: 'useINP', Component: UseINPDemo },
   useCLS: { label: 'useCLS', Component: UseCLSDemo },
   useLongTasks: { label: 'useLongTasks', Component: UseLongTasksDemo },
+  useMemoryStatus: { label: 'useMemoryStatus', Component: UseMemoryStatusDemo },
   useFps: { label: 'useFps', Component: UseFpsDemo },
   useDebouncedState: { label: 'useDebouncedState', Component: UseDebouncedStateDemo },
   useThrottledState: { label: 'useThrottledState', Component: UseThrottledStateDemo },

--- a/examples/stackblitz/hooks-playground/src/demos/useMemoryStatusDemo.tsx
+++ b/examples/stackblitz/hooks-playground/src/demos/useMemoryStatusDemo.tsx
@@ -1,0 +1,38 @@
+import { useMemoryStatus } from 'react-perf-hooks';
+
+function formatBytes(value: number | null): string {
+  if (value === null) return 'n/a';
+
+  return `${(value / 1024 / 1024).toFixed(1)} MB`;
+}
+
+export function UseMemoryStatusDemo() {
+  const { usedJSHeapSize, totalJSHeapSize, memoryLimit, isRiskZone, isSupported } = useMemoryStatus(
+    {
+      warningThresholdRatio: 0.8,
+      interval: 5000,
+    },
+  );
+
+  return (
+    <section>
+      <h2>useMemoryStatus demo</h2>
+      <p>
+        Chromium exposes JavaScript heap telemetry through the non-standard performance.memory API.
+        Safari and Firefox safely report unsupported.
+      </p>
+      <dl>
+        <dt>Supported</dt>
+        <dd>{isSupported ? 'Yes' : 'No'}</dd>
+        <dt>Used heap</dt>
+        <dd>{formatBytes(usedJSHeapSize)}</dd>
+        <dt>Total heap</dt>
+        <dd>{formatBytes(totalJSHeapSize)}</dd>
+        <dt>Heap limit</dt>
+        <dd>{formatBytes(memoryLimit)}</dd>
+        <dt>Risk zone</dt>
+        <dd>{isRiskZone ? 'Yes' : 'No'}</dd>
+      </dl>
+    </section>
+  );
+}

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -17,6 +17,7 @@ const sidebars: SidebarsConfig = {
         'hooks/use-inp',
         'hooks/use-cls',
         'hooks/use-long-tasks',
+        'hooks/use-memory-status',
         'hooks/use-debounced-state',
         'hooks/use-throttled-state',
         'hooks/use-intersection-observer',

--- a/src/hooks/useMemoryStatus/index.ts
+++ b/src/hooks/useMemoryStatus/index.ts
@@ -1,0 +1,165 @@
+import { useEffect, useState } from 'react';
+
+export interface UseMemoryStatusOptions {
+  /**
+   * Ratio of used heap to total heap that marks the app as memory-risky.
+   * Defaults to `0.8`.
+   */
+  warningThresholdRatio?: number;
+  /**
+   * Polling interval in milliseconds.
+   * Defaults to `5000`.
+   */
+  interval?: number;
+  /**
+   * Set to `false` to disable polling.
+   * Defaults to `true`.
+   */
+  enabled?: boolean;
+}
+
+export interface UseMemoryStatusReturn {
+  /** Current used JavaScript heap size in bytes, or `null` when unsupported. */
+  usedJSHeapSize: number | null;
+  /** Current total allocated JavaScript heap size in bytes, or `null` when unsupported. */
+  totalJSHeapSize: number | null;
+  /** Browser JavaScript heap size limit in bytes, or `null` when unsupported. */
+  jsHeapSizeLimit: number | null;
+  /** Alias for `jsHeapSizeLimit`, matching common memory monitoring terminology. */
+  memoryLimit: number | null;
+  /** Whether `usedJSHeapSize / totalJSHeapSize` exceeds `warningThresholdRatio`. */
+  isRiskZone: boolean;
+  /** Whether this browser exposes Chromium's non-standard `performance.memory` API. */
+  isSupported: boolean;
+}
+
+interface PerformanceMemoryLike {
+  usedJSHeapSize: number;
+  totalJSHeapSize: number;
+  jsHeapSizeLimit: number;
+}
+
+interface PerformanceWithMemory extends Performance {
+  memory?: PerformanceMemoryLike;
+}
+
+const DEFAULT_WARNING_THRESHOLD_RATIO = 0.8;
+const DEFAULT_INTERVAL = 5000;
+
+const unsupportedState: UseMemoryStatusReturn = {
+  usedJSHeapSize: null,
+  totalJSHeapSize: null,
+  jsHeapSizeLimit: null,
+  memoryLimit: null,
+  isRiskZone: false,
+  isSupported: false,
+};
+
+function normalizeWarningThresholdRatio(ratio: number): number {
+  return Number.isFinite(ratio) && ratio >= 0 ? ratio : DEFAULT_WARNING_THRESHOLD_RATIO;
+}
+
+function normalizeInterval(interval: number): number {
+  return Number.isFinite(interval) && interval > 0
+    ? Math.max(1, Math.floor(interval))
+    : DEFAULT_INTERVAL;
+}
+
+function getPerformanceMemory(): PerformanceMemoryLike | null {
+  if (typeof window === 'undefined') return null;
+
+  const memory = (window.performance as PerformanceWithMemory | undefined)?.memory;
+
+  if (
+    !memory ||
+    !Number.isFinite(memory.usedJSHeapSize) ||
+    !Number.isFinite(memory.totalJSHeapSize) ||
+    !Number.isFinite(memory.jsHeapSizeLimit)
+  ) {
+    return null;
+  }
+
+  return memory;
+}
+
+function toMemoryStatus(
+  memory: PerformanceMemoryLike,
+  warningThresholdRatio: number,
+): UseMemoryStatusReturn {
+  const isRiskZone =
+    memory.totalJSHeapSize > 0 &&
+    memory.usedJSHeapSize / memory.totalJSHeapSize >= warningThresholdRatio;
+
+  return {
+    usedJSHeapSize: memory.usedJSHeapSize,
+    totalJSHeapSize: memory.totalJSHeapSize,
+    jsHeapSizeLimit: memory.jsHeapSizeLimit,
+    memoryLimit: memory.jsHeapSizeLimit,
+    isRiskZone,
+    isSupported: true,
+  };
+}
+
+/**
+ * Polls Chromium's non-standard `performance.memory` API and exposes JavaScript
+ * heap telemetry for dashboards, editors, and other memory-sensitive views.
+ *
+ * @example
+ * function MemoryBadge() {
+ *   const { usedJSHeapSize, totalJSHeapSize, isRiskZone, isSupported } = useMemoryStatus();
+ *
+ *   if (!isSupported) return null;
+ *
+ *   return <span>{isRiskZone ? 'High memory pressure' : `${usedJSHeapSize} / ${totalJSHeapSize}`}</span>;
+ * }
+ */
+export function useMemoryStatus(options: UseMemoryStatusOptions = {}): UseMemoryStatusReturn {
+  const {
+    warningThresholdRatio = DEFAULT_WARNING_THRESHOLD_RATIO,
+    interval = DEFAULT_INTERVAL,
+    enabled = true,
+  } = options;
+  const normalizedWarningThresholdRatio = normalizeWarningThresholdRatio(warningThresholdRatio);
+  const normalizedInterval = normalizeInterval(interval);
+  const [state, setState] = useState<UseMemoryStatusReturn>(() => {
+    const memory = getPerformanceMemory();
+    return memory ? toMemoryStatus(memory, normalizedWarningThresholdRatio) : unsupportedState;
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const updateMemoryStatus = () => {
+      const memory = getPerformanceMemory();
+      const nextState = memory
+        ? toMemoryStatus(memory, normalizedWarningThresholdRatio)
+        : unsupportedState;
+
+      setState((current) => {
+        if (
+          current.usedJSHeapSize === nextState.usedJSHeapSize &&
+          current.totalJSHeapSize === nextState.totalJSHeapSize &&
+          current.jsHeapSizeLimit === nextState.jsHeapSizeLimit &&
+          current.isRiskZone === nextState.isRiskZone &&
+          current.isSupported === nextState.isSupported
+        ) {
+          return current;
+        }
+
+        return nextState;
+      });
+    };
+
+    updateMemoryStatus();
+
+    if (!getPerformanceMemory()) return;
+
+    const intervalId = window.setInterval(updateMemoryStatus, normalizedInterval);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [enabled, normalizedInterval, normalizedWarningThresholdRatio]);
+
+  return state;
+}

--- a/src/hooks/useMemoryStatus/useMemoryStatus.test.tsx
+++ b/src/hooks/useMemoryStatus/useMemoryStatus.test.tsx
@@ -1,0 +1,148 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMemoryStatus } from './index';
+
+interface MutablePerformanceMemory {
+  usedJSHeapSize: number;
+  totalJSHeapSize: number;
+  jsHeapSizeLimit: number;
+}
+
+const originalMemoryDescriptor = Object.getOwnPropertyDescriptor(performance, 'memory');
+let memory: MutablePerformanceMemory;
+
+function installPerformanceMemory(nextMemory: MutablePerformanceMemory): void {
+  memory = nextMemory;
+
+  Object.defineProperty(performance, 'memory', {
+    configurable: true,
+    get: () => memory,
+  });
+}
+
+function uninstallPerformanceMemory(): void {
+  if (originalMemoryDescriptor) {
+    Object.defineProperty(performance, 'memory', originalMemoryDescriptor);
+    return;
+  }
+
+  delete (performance as Performance & { memory?: MutablePerformanceMemory }).memory;
+}
+
+describe('useMemoryStatus', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    installPerformanceMemory({
+      usedJSHeapSize: 40,
+      totalJSHeapSize: 100,
+      jsHeapSizeLimit: 1000,
+    });
+  });
+
+  afterEach(() => {
+    uninstallPerformanceMemory();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('returns the current heap telemetry when performance.memory is supported', () => {
+    const { result } = renderHook(() => useMemoryStatus());
+
+    expect(result.current).toEqual({
+      usedJSHeapSize: 40,
+      totalJSHeapSize: 100,
+      jsHeapSizeLimit: 1000,
+      memoryLimit: 1000,
+      isRiskZone: false,
+      isSupported: true,
+    });
+  });
+
+  it('returns unsupported state without throwing when performance.memory is unavailable', () => {
+    uninstallPerformanceMemory();
+
+    const { result } = renderHook(() => useMemoryStatus());
+
+    expect(result.current).toEqual({
+      usedJSHeapSize: null,
+      totalJSHeapSize: null,
+      jsHeapSizeLimit: null,
+      memoryLimit: null,
+      isRiskZone: false,
+      isSupported: false,
+    });
+  });
+
+  it('polls memory on the configured interval', () => {
+    const { result } = renderHook(() => useMemoryStatus({ interval: 1000 }));
+
+    expect(result.current.usedJSHeapSize).toBe(40);
+
+    memory = {
+      usedJSHeapSize: 60,
+      totalJSHeapSize: 100,
+      jsHeapSizeLimit: 1000,
+    };
+
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+
+    expect(result.current.usedJSHeapSize).toBe(40);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(result.current.usedJSHeapSize).toBe(60);
+  });
+
+  it('flags risk zone when used heap reaches the configured ratio of total heap', () => {
+    const { result } = renderHook(() =>
+      useMemoryStatus({ warningThresholdRatio: 0.75, interval: 1000 }),
+    );
+
+    expect(result.current.isRiskZone).toBe(false);
+
+    memory = {
+      usedJSHeapSize: 75,
+      totalJSHeapSize: 100,
+      jsHeapSizeLimit: 1000,
+    };
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.isRiskZone).toBe(true);
+  });
+
+  it('does not divide by zero when total heap is zero', () => {
+    installPerformanceMemory({
+      usedJSHeapSize: 1,
+      totalJSHeapSize: 0,
+      jsHeapSizeLimit: 1000,
+    });
+
+    const { result } = renderHook(() => useMemoryStatus({ warningThresholdRatio: 0 }));
+
+    expect(result.current.isRiskZone).toBe(false);
+  });
+
+  it('does not start polling when disabled', () => {
+    const setIntervalSpy = vi.spyOn(window, 'setInterval');
+
+    renderHook(() => useMemoryStatus({ enabled: false }));
+
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+  });
+
+  it('clears the polling interval on unmount', () => {
+    const clearIntervalSpy = vi.spyOn(window, 'clearInterval');
+    const { unmount } = renderHook(() => useMemoryStatus({ interval: 1000 }));
+
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,9 @@ export type {
 export { useFps } from './hooks/useFps';
 export type { UseFpsOptions, UseFpsReturn } from './hooks/useFps';
 
+export { useMemoryStatus } from './hooks/useMemoryStatus';
+export type { UseMemoryStatusOptions, UseMemoryStatusReturn } from './hooks/useMemoryStatus';
+
 export { useDebouncedState } from './hooks/useDebouncedState';
 export type { DebouncedStateStats, UseDebouncedStateReturn } from './hooks/useDebouncedState';
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,6 +14,7 @@ const hooks = [
   'useINP',
   'useCLS',
   'useLongTasks',
+  'useMemoryStatus',
   'useDebouncedState',
   'useThrottledState',
   'useIntersectionObserver',
@@ -58,7 +59,7 @@ export default function Home(): ReactNode {
           <Heading as="h2">What this docs site includes</Heading>
           <div className={styles.cardGrid}>
             <article className={styles.card}>
-              <h3>12 hook references</h3>
+              <h3>13 hook references</h3>
               <p>
                 Every hook has signature details, parameter and return tables, and copy-ready usage
                 examples.


### PR DESCRIPTION
## Description
Memory leaks and Garbage Collector (GC) thrashing are critical issues in complex Single Page Applications (e.g., heavy dashboards, image editors). We should introduce a `useMemoryStatus` hook that wraps the Chromium-specific `performance.memory` API to safely expose heap telemetry.

## Proposed API
```typescript
const { usedJSHeapSize, totalJSHeapSize, memoryLimit, isRiskZone } = useMemoryStatus({
  warningThresholdRatio: 0.8, // 80% of total heap used
  interval: 5000 // Poll every 5 seconds
});
```

Implementation Details
1. Guard against non-supported browsers (Safari, Firefox) by safely checking if window.performance?.memory exists. Return null or a supported flag if unavailable.
2. Use a safe interval-based polling mechanism.
3. Expose metrics: usedJSHeapSize, totalJSHeapSize, and jsHeapSizeLimit.
Acceptance Criteria
- [ ] Hook executes safely across all browsers without throwing runtime errors.
- [ ] Correctly calculates isRiskZone when the heap size exceeds the configured ratio.
- [ ] Uses a clean interval lifecycle that clears itself on unmount.