### PR TITLE
Feat: Add useAllocationTracker using FinalizationRegistry for leak detection  

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ npm install web-vitals
 | Hook | What it solves | Docs |
 |------|---------------|------|
 | `useRenderTracker` | Find components that re-render too often and why | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-render-tracker) |
+| `useAllocationTracker` | Detect potentially retained heavy objects after component unmount in development | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-allocation-tracker) |
 | `useRenderBudget` | Warn when a single render commit exceeds a time budget (default: 16ms) | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-render-budget) |
 | `usePerformanceMark` | Precise timing of any code path via the Performance API | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-performance-mark) |
 | `useComponentLifecycle` | Track mount/unmount timings and live component lifetime | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-component-lifecycle) |
@@ -82,8 +83,10 @@ See the [docs overview](https://valyefimov.github.io/react-perf-hooks/docs/getti
 ## Quick start
 
 ```tsx
+import { useEffect } from 'react';
 import {
   useRenderTracker,
+  useAllocationTracker,
   useRenderBudget,
   usePerformanceMark,
   useComponentLifecycle,
@@ -100,6 +103,14 @@ import {
 function App() {
   // Track re-renders and warn if a component renders more than 10 times
   const { count } = useRenderTracker({ userId }, { name: 'App', warnAt: 10 });
+
+  // Register heavyweight allocations for post-unmount GC diagnostics in development
+  const trackAllocation = useAllocationTracker({ componentName: 'App' });
+
+  useEffect(() => {
+    const scratchBuffer = new Uint8Array(1024 * 1024 * 10);
+    trackAllocation(scratchBuffer, 'scratch buffer');
+  }, [trackAllocation]);
 
   // Warn when a render exceeds one frame budget (16ms by default)
   useRenderBudget(16, 'App');
@@ -159,6 +170,9 @@ All hooks ship with full type declarations. No `@types/*` packages needed.
 import type {
   RenderInfo,
   UseRenderTrackerOptions,
+  AllocationLeakInfo,
+  TrackAllocation,
+  UseAllocationTrackerOptions,
   UseRenderBudgetOptions,
   PerformanceMeasureResult,
   UsePerformanceMarkReturn,

--- a/docs/hooks/use-allocation-tracker.mdx
+++ b/docs/hooks/use-allocation-tracker.mdx
@@ -1,0 +1,85 @@
+---
+title: useAllocationTracker
+description: Track whether heavy objects become garbage-collectable after component unmount.
+---
+
+## Description and use case
+
+`useAllocationTracker` helps diagnose suspected memory leaks during development. Register heavy objects, caches, DOM-adjacent objects, or closure-owned allocations and the hook checks whether they still appear reachable after the component unmounts.
+
+The hook uses `FinalizationRegistry` and `WeakRef`, so it can only report a **potential** leak. JavaScript garbage collection is nondeterministic and browsers do not guarantee exactly when finalizers run.
+
+## API signature
+
+```ts
+function useAllocationTracker(options: UseAllocationTrackerOptions): TrackAllocation;
+
+type TrackAllocation = (target: object, allocationName?: string) => boolean;
+```
+
+## Parameters
+
+| Name                             | Type                            | Required | Description                                                             |
+| -------------------------------- | ------------------------------- | -------- | ----------------------------------------------------------------------- |
+| `options.componentName`          | `string`                        | Yes      | Label used in warnings and callbacks.                                   |
+| `options.enabled`                | `boolean`                       | No       | Enable/disable tracking. Defaults to dev true, production false.        |
+| `options.timeoutMs`              | `number`                        | No       | Delay after unmount before reporting a retained allocation. Default 5s. |
+| `options.onLeakDetected`         | `(componentName, info) => void` | No       | Callback for potential leaks. Defaults to `console.warn`.               |
+| `trackAllocation.target`         | `object`                        | Yes      | Object to observe through `FinalizationRegistry` and `WeakRef`.         |
+| `trackAllocation.allocationName` | `string`                        | No       | Optional label for the tracked allocation.                              |
+
+## Return value
+
+`useAllocationTracker` returns a `trackAllocation` function. It returns `true` when the object was registered and `false` when tracking is disabled or unsupported by the runtime.
+
+## Code example
+
+```tsx
+import { useEffect } from 'react';
+import { useAllocationTracker } from 'react-perf-hooks';
+
+export function HeavyEditorComponent() {
+  const trackAllocation = useAllocationTracker({
+    componentName: 'HeavyEditorComponent',
+    timeoutMs: 8000,
+    onLeakDetected: (name, info) => {
+      console.warn(`Potential memory leak detected in ${name}`, info);
+    },
+  });
+
+  useEffect(() => {
+    const heavyData = new Uint8Array(1024 * 1024 * 10);
+    const handleResize = () => {
+      heavyData[0] = heavyData[0] + 1;
+    };
+
+    window.addEventListener('resize', handleResize);
+    trackAllocation(heavyData, '10MB editor buffer');
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [trackAllocation]);
+
+  return <div>Editor</div>;
+}
+```
+
+## Testing leaks in Chrome DevTools
+
+1. Run your app in development mode with React Strict Mode behavior understood. Strict Mode intentionally mounts, unmounts, and remounts components in development.
+2. Open Chrome DevTools and go to **Memory**.
+3. Enable manual garbage collection if needed by launching Chrome with `--js-flags="--expose-gc"` or use the trash-can **Collect garbage** button in the Memory panel.
+4. Navigate to the screen that mounts the component and perform the interaction that creates the allocation.
+5. Navigate away or otherwise unmount the component.
+6. Click **Collect garbage** several times, then wait longer than `timeoutMs`.
+7. If `onLeakDetected` fires, take a heap snapshot and search for your allocation label, retained closure, event listener, cache, or object constructor.
+8. Fix the retaining reference, then repeat the same flow. A disappearing warning is useful evidence, but heap snapshots are the source of truth.
+
+## Important limitations
+
+- `FinalizationRegistry` callbacks are not guaranteed to run promptly, or before page close.
+- A warning means “still reachable after the timeout,” not mathematical proof of a leak.
+- Short timeouts produce false positives. Prefer 5-10 seconds during manual debugging.
+- Production builds default to a no-op path and register no objects.
+- The hook does not retain tracked targets strongly; it stores metadata and a `WeakRef`.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -9,6 +9,7 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: [
         'hooks/use-render-tracker',
+        'hooks/use-allocation-tracker',
         'hooks/use-render-budget',
         'hooks/use-performance-mark',
         'hooks/use-component-lifecycle',

--- a/src/hooks/useAllocationTracker/index.ts
+++ b/src/hooks/useAllocationTracker/index.ts
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+export interface AllocationLeakInfo {
+  /** Stable id assigned to this tracked allocation. */
+  id: number;
+  /** Component label supplied to the hook. */
+  componentName: string;
+  /** Optional label supplied when the allocation was registered. */
+  allocationName?: string;
+  /** Timestamp captured with performance.now() when tracking started. */
+  trackedAt: number;
+  /** Timestamp captured when the owner component unmounted. */
+  unmountedAt: number;
+  /** Number of milliseconds waited after unmount before reporting. */
+  timeoutMs: number;
+}
+
+export interface UseAllocationTrackerOptions {
+  /** Display name used in warnings and callbacks. */
+  componentName: string;
+  /**
+   * Enable tracking. Defaults to true in development, false in production.
+   * Pass `true` only for diagnostic builds where FinalizationRegistry is available.
+   */
+  enabled?: boolean;
+  /**
+   * Time to wait after unmount before treating a still-reachable allocation as suspicious.
+   * Defaults to 5000ms.
+   */
+  timeoutMs?: number;
+  /**
+   * Called when an allocation is still reachable after the unmount timeout.
+   * This is a heuristic signal, not proof of a leak.
+   */
+  onLeakDetected?: (componentName: string, info: AllocationLeakInfo) => void;
+}
+
+export type TrackAllocation = (target: object, allocationName?: string) => boolean;
+
+type RegistryHeldValue = {
+  id: number;
+};
+
+type AllocationRecord = {
+  id: number;
+  componentName: string;
+  allocationName?: string;
+  trackedAt: number;
+  timeoutMs: number;
+  onLeakDetected?: (componentName: string, info: AllocationLeakInfo) => void;
+  weakRef?: WeakRef<object>;
+  collected: boolean;
+  unmountedAt?: number;
+  timerId?: ReturnType<typeof setTimeout>;
+};
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+let nextAllocationId = 1;
+const records = new Map<number, AllocationRecord>();
+
+const getNow = (): number => {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+
+  return Date.now();
+};
+
+const hasAllocationTrackingSupport = (): boolean =>
+  typeof FinalizationRegistry !== 'undefined' && typeof WeakRef !== 'undefined';
+
+let registry: FinalizationRegistry<RegistryHeldValue> | undefined;
+
+const getRegistry = (): FinalizationRegistry<RegistryHeldValue> | undefined => {
+  if (!hasAllocationTrackingSupport()) return undefined;
+
+  registry ??= new FinalizationRegistry<RegistryHeldValue>(({ id }) => {
+    const record = records.get(id);
+
+    if (!record) return;
+
+    record.collected = true;
+
+    if (record.timerId) {
+      clearTimeout(record.timerId);
+    }
+
+    records.delete(id);
+  });
+
+  return registry;
+};
+
+const normalizeTimeout = (timeoutMs: number | undefined): number => {
+  if (timeoutMs == null) return DEFAULT_TIMEOUT_MS;
+  if (!Number.isFinite(timeoutMs) || timeoutMs < 0) return DEFAULT_TIMEOUT_MS;
+
+  return timeoutMs;
+};
+
+const scheduleLeakCheck = (record: AllocationRecord, unmountedAt: number): void => {
+  record.unmountedAt = unmountedAt;
+
+  record.timerId = setTimeout(() => {
+    const latestRecord = records.get(record.id);
+
+    if (!latestRecord || latestRecord.collected) return;
+
+    if (latestRecord.weakRef && latestRecord.weakRef.deref() === undefined) {
+      records.delete(latestRecord.id);
+      return;
+    }
+
+    const info: AllocationLeakInfo = {
+      id: latestRecord.id,
+      componentName: latestRecord.componentName,
+      allocationName: latestRecord.allocationName,
+      trackedAt: latestRecord.trackedAt,
+      unmountedAt,
+      timeoutMs: latestRecord.timeoutMs,
+    };
+
+    if (latestRecord.onLeakDetected) {
+      latestRecord.onLeakDetected(latestRecord.componentName, info);
+    } else {
+      console.warn(
+        `[useAllocationTracker] Potential memory leak detected in "${latestRecord.componentName}". ` +
+          `Allocation${latestRecord.allocationName ? ` "${latestRecord.allocationName}"` : ''} ` +
+          `was still reachable ${latestRecord.timeoutMs}ms after unmount.`,
+      );
+    }
+  }, record.timeoutMs);
+};
+
+/**
+ * Tracks whether registered objects become eligible for garbage collection after unmount.
+ *
+ * This hook uses FinalizationRegistry and WeakRef in development to flag allocations that
+ * remain reachable after their owner component unmounts. The signal is heuristic because
+ * JavaScript garbage collection and finalizer delivery are intentionally nondeterministic.
+ */
+export function useAllocationTracker(options: UseAllocationTrackerOptions): TrackAllocation {
+  const {
+    componentName,
+    enabled = process.env.NODE_ENV !== 'production',
+    timeoutMs,
+    onLeakDetected,
+  } = options;
+
+  const allocationIdsRef = useRef<number[]>([]);
+  const optionsRef = useRef({
+    componentName,
+    timeoutMs: normalizeTimeout(timeoutMs),
+    onLeakDetected,
+  });
+
+  optionsRef.current = {
+    componentName,
+    timeoutMs: normalizeTimeout(timeoutMs),
+    onLeakDetected,
+  };
+
+  const canTrack = enabled && hasAllocationTrackingSupport();
+
+  useEffect(() => {
+    if (!canTrack) return;
+
+    return () => {
+      const unmountedAt = getNow();
+      // This ref is a mutable allocation registry, not a rendered node; cleanup needs latest IDs.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      const allocationIds = allocationIdsRef.current;
+
+      for (const id of allocationIds) {
+        const record = records.get(id);
+
+        if (!record || record.collected || record.unmountedAt != null) continue;
+
+        scheduleLeakCheck(record, unmountedAt);
+      }
+    };
+  }, [canTrack]);
+
+  return useCallback<TrackAllocation>(
+    (target, allocationName) => {
+      if (!canTrack) return false;
+
+      const allocationRegistry = getRegistry();
+
+      if (!allocationRegistry) return false;
+
+      const id = nextAllocationId++;
+      const currentOptions = optionsRef.current;
+      const record: AllocationRecord = {
+        id,
+        componentName: currentOptions.componentName,
+        allocationName,
+        trackedAt: getNow(),
+        timeoutMs: currentOptions.timeoutMs,
+        onLeakDetected: currentOptions.onLeakDetected,
+        weakRef: new WeakRef(target),
+        collected: false,
+      };
+
+      records.set(id, record);
+      allocationIdsRef.current.push(id);
+      allocationRegistry.register(target, { id });
+
+      return true;
+    },
+    [canTrack],
+  );
+}
+
+export const __allocationTrackerInternals = {
+  records,
+  hasAllocationTrackingSupport,
+};

--- a/src/hooks/useAllocationTracker/index.ts
+++ b/src/hooks/useAllocationTracker/index.ts
@@ -164,8 +164,6 @@ export function useAllocationTracker(options: UseAllocationTrackerOptions): Trac
   const canTrack = enabled && hasAllocationTrackingSupport();
 
   useEffect(() => {
-    if (!canTrack) return;
-
     return () => {
       const unmountedAt = getNow();
       // This ref is a mutable allocation registry, not a rendered node; cleanup needs latest IDs.
@@ -180,7 +178,7 @@ export function useAllocationTracker(options: UseAllocationTrackerOptions): Trac
         scheduleLeakCheck(record, unmountedAt);
       }
     };
-  }, [canTrack]);
+  }, []);
 
   return useCallback<TrackAllocation>(
     (target, allocationName) => {

--- a/src/hooks/useAllocationTracker/useAllocationTracker.test.tsx
+++ b/src/hooks/useAllocationTracker/useAllocationTracker.test.tsx
@@ -78,6 +78,47 @@ describe('useAllocationTracker', () => {
     );
   });
 
+  it('does not treat disabling tracking as an unmount', () => {
+    const onLeakDetected = vi.fn();
+    const { result, rerender, unmount } = renderHook(
+      ({ enabled }) =>
+        useAllocationTracker({
+          componentName: 'ToggleComponent',
+          enabled,
+          timeoutMs: 10,
+          onLeakDetected,
+        }),
+      {
+        initialProps: { enabled: true },
+      },
+    );
+
+    result.current({ retained: true }, 'cache');
+
+    rerender({ enabled: false });
+
+    act(() => vi.advanceTimersByTime(10));
+
+    expect(onLeakDetected).not.toHaveBeenCalled();
+
+    const [record] = __allocationTrackerInternals.records.values();
+    expect(record.unmountedAt).toBeUndefined();
+
+    unmount();
+
+    act(() => vi.advanceTimersByTime(10));
+
+    expect(onLeakDetected).toHaveBeenCalledTimes(1);
+    expect(onLeakDetected).toHaveBeenCalledWith(
+      'ToggleComponent',
+      expect.objectContaining({
+        allocationName: 'cache',
+        componentName: 'ToggleComponent',
+        timeoutMs: 10,
+      }),
+    );
+  });
+
   it('falls back to console.warn when no leak callback is provided', () => {
     const { result, unmount } = renderHook(() =>
       useAllocationTracker({

--- a/src/hooks/useAllocationTracker/useAllocationTracker.test.tsx
+++ b/src/hooks/useAllocationTracker/useAllocationTracker.test.tsx
@@ -1,0 +1,141 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { __allocationTrackerInternals, useAllocationTracker } from './index';
+
+describe('useAllocationTracker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    __allocationTrackerInternals.records.clear();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    __allocationTrackerInternals.records.clear();
+  });
+
+  it('registers target objects when enabled and supported', () => {
+    const { result } = renderHook(() =>
+      useAllocationTracker({ componentName: 'HeavyEditor', enabled: true }),
+    );
+
+    const target = new Uint8Array(1024);
+
+    expect(result.current(target, 'buffer')).toBe(true);
+    expect(__allocationTrackerInternals.records.size).toBe(1);
+
+    const [record] = __allocationTrackerInternals.records.values();
+
+    expect(record.componentName).toBe('HeavyEditor');
+    expect(record.allocationName).toBe('buffer');
+  });
+
+  it('returns false and stores no records when disabled', () => {
+    const { result, unmount } = renderHook(() =>
+      useAllocationTracker({ componentName: 'HeavyEditor', enabled: false }),
+    );
+
+    expect(result.current({})).toBe(false);
+
+    unmount();
+    act(() => vi.runAllTimers());
+
+    expect(__allocationTrackerInternals.records.size).toBe(0);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('reports a potential leak after unmount timeout', () => {
+    const onLeakDetected = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useAllocationTracker({
+        componentName: 'HeavyEditor',
+        enabled: true,
+        timeoutMs: 250,
+        onLeakDetected,
+      }),
+    );
+
+    const target = { large: new Uint8Array(1024) };
+
+    result.current(target, 'cache');
+    unmount();
+
+    act(() => vi.advanceTimersByTime(249));
+    expect(onLeakDetected).not.toHaveBeenCalled();
+
+    act(() => vi.advanceTimersByTime(1));
+
+    expect(onLeakDetected).toHaveBeenCalledTimes(1);
+    expect(onLeakDetected).toHaveBeenCalledWith(
+      'HeavyEditor',
+      expect.objectContaining({
+        allocationName: 'cache',
+        componentName: 'HeavyEditor',
+        timeoutMs: 250,
+      }),
+    );
+  });
+
+  it('falls back to console.warn when no leak callback is provided', () => {
+    const { result, unmount } = renderHook(() =>
+      useAllocationTracker({
+        componentName: 'FallbackComponent',
+        enabled: true,
+        timeoutMs: 10,
+      }),
+    );
+
+    result.current({}, 'listener');
+    unmount();
+
+    act(() => vi.advanceTimersByTime(10));
+
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('FallbackComponent'));
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('listener'));
+  });
+
+  it('does not report records already marked collected before timeout', () => {
+    const onLeakDetected = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useAllocationTracker({
+        componentName: 'CollectedComponent',
+        enabled: true,
+        timeoutMs: 10,
+        onLeakDetected,
+      }),
+    );
+
+    result.current({}, 'temporary');
+
+    const [record] = __allocationTrackerInternals.records.values();
+    record.collected = true;
+
+    unmount();
+    act(() => vi.advanceTimersByTime(10));
+
+    expect(onLeakDetected).not.toHaveBeenCalled();
+  });
+
+  it('uses the default timeout for invalid timeout values', () => {
+    const onLeakDetected = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useAllocationTracker({
+        componentName: 'InvalidTimeout',
+        enabled: true,
+        timeoutMs: Number.NaN,
+        onLeakDetected,
+      }),
+    );
+
+    result.current({});
+    unmount();
+
+    act(() => vi.advanceTimersByTime(4999));
+    expect(onLeakDetected).not.toHaveBeenCalled();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(onLeakDetected).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,13 @@
 export { useRenderTracker } from './hooks/useRenderTracker';
 export type { RenderInfo, UseRenderTrackerOptions } from './hooks/useRenderTracker';
 
+export { useAllocationTracker } from './hooks/useAllocationTracker';
+export type {
+  AllocationLeakInfo,
+  TrackAllocation,
+  UseAllocationTrackerOptions,
+} from './hooks/useAllocationTracker';
+
 export { useRenderBudget } from './hooks/useRenderBudget';
 export type { UseRenderBudgetOptions } from './hooks/useRenderBudget';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "lib": ["ES2018", "DOM", "DOM.Iterable"],
+    "lib": ["ES2018", "ES2021.WeakRef", "DOM", "DOM.Iterable"],
     "types": ["node"],
     "module": "ESNext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Description
Detecting memory leaks within React components during development is notoriously hard. We can build a breakthrough hook `useAllocationTracker` that leverages modern JavaScript `FinalizationRegistry` and `WeakRef` to track whether heavy objects or event closures are properly garbage collected after a component unmounts.

## Proposed API
```typescript
const trackAllocation = useAllocationTracker({
  componentName: 'HeavyEditorComponent',
  onLeakDetected: (name) => console.warn(`Potential memory leak detected in ${name}`)
});

useEffect(() => {
  const heavyData = new Uint8Array(1024 * 1024 * 10); // 10MB
  trackAllocation(heavyData);
}, []);
```

Implementation Details
1. In development mode, initialize a global or hook-scoped FinalizationRegistry.
2. Upon calling trackAllocation(object), register the object with the registry, passing a token (like the component name).
3. If the component unmounts and a simulated GC cycle occurs (or over a specific timeout during development), verify if the registry cleanup callback triggers. If it doesn't trigger within an expected threshold under memory pressure, flag a potential leak.
4. Alternative/Complementary implementation: Monitor if internal hooks/closures are retained in memory past the unmount cycle.
Acceptance Criteria
• [ ] Features a zero-overhead no-op setup in production mode.
• [ ] Provides a clean mechanism to register target objects for GC lifecycle tracking.
• [ ] Includes exhaustive documentation explaining how to test leaks in DevTools via manual GC triggers.