### PR TITLE
Feat: Add useNetworkEfficiency to evaluate resource payloads  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ npm-debug.log*
 pnpm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.codex
+.claude
+graphify-out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+When the user types `/graphify`, use the installed graphify skill or instructions before doing anything else.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- Dirty graphify-out/ files are expected after hooks or incremental updates; dirty graph files are not a reason to skip graphify. Only skip graphify if the task is about stale or incorrect graph output, or the user explicitly says not to use it.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ npm install web-vitals
 | `useCLS` | Component-scoped Cumulative Layout Shift tracking for a specific DOM node | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-cls) |
 | `useLongTasks` | Log main-thread freezes over 50ms and attach them to the current screen | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-long-tasks) |
 | `useMemoryStatus` | Monitor Chromium JavaScript heap usage and flag high memory pressure | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-memory-status) |
+| `useNetworkEfficiency` | Flag oversized Resource Timing payloads, with mobile network threshold adjustments | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-network-efficiency) |
 | `useDebouncedState` | Debounced `useState` with render-skip profiling counters | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-debounced-state) |
 | `useThrottledState` | Throttled `useState` with dropped-update profiling counters | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-throttled-state) |
 | `useIntersectionObserver` | Lazy-loading visibility state plus first-visible and total-visible metrics | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-intersection-observer) |
@@ -97,6 +98,7 @@ import {
   useCLS,
   useLongTasks,
   useMemoryStatus,
+  useNetworkEfficiency,
   useDebouncedState,
   useThrottledState,
   useIntersectionObserver,
@@ -150,6 +152,13 @@ function App() {
   // Monitor Chromium heap telemetry and flag high memory pressure
   const memory = useMemoryStatus({ warningThresholdRatio: 0.8, interval: 5000 });
 
+  // Warn when an API response payload is too large for current network conditions
+  const network = useNetworkEfficiency({
+    resourceFilter: '/api/v1/heavy-data',
+    maxSizeInBytes: 1024 * 500,
+    onWarning: (entry) => navigator.sendBeacon('/analytics/network-payload', JSON.stringify(entry)),
+  });
+
   // Debounce state updates and inspect profiling counters
   const [query, setQuery, stats] = useDebouncedState('', 250);
 
@@ -202,6 +211,11 @@ import type {
   UseLongTasksReturn,
   UseMemoryStatusOptions,
   UseMemoryStatusReturn,
+  NetworkEfficiencyEntry,
+  NetworkEffectiveType,
+  NetworkResourceFilter,
+  UseNetworkEfficiencyOptions,
+  UseNetworkEfficiencyReturn,
   DebouncedStateStats,
   UseDebouncedStateReturn,
   ThrottledStateStats,

--- a/docs/hooks/use-network-efficiency.mdx
+++ b/docs/hooks/use-network-efficiency.mdx
@@ -1,0 +1,71 @@
+---
+title: useNetworkEfficiency
+description: Monitor Resource Timing payload sizes and flag bloated network responses.
+---
+
+## Description and use case
+
+`useNetworkEfficiency` reads Resource Timing entries and reports payload sizes for matching resources. It is useful for API-heavy screens where a response that feels acceptable on desktop broadband can become expensive on mobile networks.
+
+The hook prefers `transferSize`, then falls back to `encodedBodySize` and `decodedBodySize` when the browser exposes those fields. Cross-origin resources may report `0` unless the response includes the appropriate `Timing-Allow-Origin` header.
+
+When the Network Information API is available, the configured threshold is lowered for `3g`, `2g`, and `slow-2g` connections. Browsers without that API keep the configured threshold and continue to work.
+
+## API signature
+
+```ts
+function useNetworkEfficiency(options?: UseNetworkEfficiencyOptions): UseNetworkEfficiencyReturn;
+```
+
+## Parameters
+
+| Name                     | Type                                  | Required | Description                                                     |
+| ------------------------ | ------------------------------------- | -------- | --------------------------------------------------------------- |
+| `options.resourceFilter` | `string \| RegExp \| (entry) => bool` | No       | Matches resource URLs. Omit to inspect all resource entries.    |
+| `options.maxSizeInBytes` | `number`                              | No       | Base payload threshold in bytes. Default `512000` (500KB).      |
+| `options.onWarning`      | `(entry) => void`                     | No       | Called when a matching payload exceeds the effective threshold. |
+| `options.enabled`        | `boolean`                             | No       | Set `false` to disable resource scanning and observation.       |
+
+## Return value
+
+| Field                     | Type                             | Description                                                          |
+| ------------------------- | -------------------------------- | -------------------------------------------------------------------- |
+| `lastPayloadSize`         | `number \| null`                 | Latest matching payload size in bytes, or `null` before a match.     |
+| `isInefficient`           | `boolean`                        | Whether the latest matching payload exceeds the effective threshold. |
+| `latest`                  | `NetworkEfficiencyEntry \| null` | Latest matching resource summary.                                    |
+| `effectiveMaxSizeInBytes` | `number`                         | Threshold after Network Information API adjustments.                 |
+| `effectiveType`           | `string \| null`                 | Connection type such as `3g`, or `null` when unavailable.            |
+| `isSupported`             | `boolean`                        | Whether this browser exposes Resource Timing entries.                |
+
+## Code example
+
+```tsx
+import { useNetworkEfficiency } from 'react-perf-hooks';
+
+export function HeavyDataProbe() {
+  const { lastPayloadSize, isInefficient, effectiveMaxSizeInBytes, effectiveType } =
+    useNetworkEfficiency({
+      resourceFilter: '/api/v1/heavy-data',
+      maxSizeInBytes: 1024 * 500,
+      onWarning: (entry) => {
+        navigator.sendBeacon('/analytics/network-payload', JSON.stringify(entry));
+      },
+    });
+
+  return (
+    <span>
+      {isInefficient
+        ? `Payload ${formatBytes(lastPayloadSize)} exceeded ${formatBytes(effectiveMaxSizeInBytes)}${
+            effectiveType ? ` on ${effectiveType}` : ''
+          }`
+        : null}
+    </span>
+  );
+}
+
+function formatBytes(value: number | null) {
+  if (value === null) return 'n/a';
+
+  return `${(value / 1024).toFixed(0)} KB`;
+}
+```

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -18,6 +18,7 @@ const sidebars: SidebarsConfig = {
         'hooks/use-inp',
         'hooks/use-cls',
         'hooks/use-long-tasks',
+        'hooks/use-fps',
         'hooks/use-memory-status',
         'hooks/use-network-efficiency',
         'hooks/use-debounced-state',

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -19,6 +19,7 @@ const sidebars: SidebarsConfig = {
         'hooks/use-cls',
         'hooks/use-long-tasks',
         'hooks/use-memory-status',
+        'hooks/use-network-efficiency',
         'hooks/use-debounced-state',
         'hooks/use-throttled-state',
         'hooks/use-intersection-observer',

--- a/src/hooks/useAllocationTracker/index.ts
+++ b/src/hooks/useAllocationTracker/index.ts
@@ -147,10 +147,10 @@ export function useAllocationTracker(options: UseAllocationTrackerOptions): Trac
     timeoutMs,
     onLeakDetected,
   } = options;
+  const normalizedTimeoutMs = normalizeTimeout(timeoutMs);
 
   const allocationIdsRef = useRef<number[]>([]);
 
-  const normalizedTimeoutMs = normalizeTimeout(timeoutMs);
   const canTrack = enabled && hasAllocationTrackingSupport();
 
   useEffect(() => {

--- a/src/hooks/useNetworkEfficiency/index.ts
+++ b/src/hooks/useNetworkEfficiency/index.ts
@@ -1,0 +1,328 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+export type NetworkResourceFilter =
+  | string
+  | RegExp
+  | ((entry: PerformanceResourceTiming) => boolean);
+
+export type NetworkEffectiveType = 'slow-2g' | '2g' | '3g' | '4g' | string;
+
+export interface NetworkEfficiencyEntry {
+  /** Full resource URL reported by the Resource Timing API. */
+  name: string;
+  /** Initiator type such as `fetch`, `xmlhttprequest`, `script`, or `img`. */
+  initiatorType: string;
+  /** Best available payload size in bytes. */
+  payloadSize: number;
+  /** Network bytes transferred, when exposed by Timing-Allow-Origin. */
+  transferSize: number;
+  /** Encoded body size in bytes, when exposed by Timing-Allow-Origin. */
+  encodedBodySize: number;
+  /** Decoded body size in bytes, when exposed by Timing-Allow-Origin. */
+  decodedBodySize: number;
+  /** Configured threshold after Network Information API adjustments. */
+  effectiveMaxSizeInBytes: number;
+  /** Network effective type, when `navigator.connection` is available. */
+  effectiveType: NetworkEffectiveType | null;
+  /** Whether the payload crosses the effective threshold. */
+  isInefficient: boolean;
+  /** Resource start time in milliseconds from navigation start. */
+  startTime: number;
+  /** Resource duration in milliseconds. */
+  duration: number;
+  /** Time when this hook converted the browser entry into state. */
+  timestamp: number;
+}
+
+export interface UseNetworkEfficiencyOptions {
+  /**
+   * Resource matcher. A string matches by substring against the full resource
+   * URL, while a RegExp is tested against it. Omit to inspect all resources.
+   */
+  resourceFilter?: NetworkResourceFilter;
+  /**
+   * Payload threshold in bytes before network conditions are applied.
+   * Defaults to `512000` (500KB).
+   */
+  maxSizeInBytes?: number;
+  /**
+   * Called whenever a matching resource exceeds the effective payload threshold.
+   */
+  onWarning?: (entry: NetworkEfficiencyEntry) => void;
+  /**
+   * Set to `false` to disable resource scanning and observation.
+   * Defaults to `true`.
+   */
+  enabled?: boolean;
+}
+
+export interface UseNetworkEfficiencyReturn {
+  /** Latest matching resource payload size in bytes, or `null` before a match. */
+  lastPayloadSize: number | null;
+  /** Whether the latest matching resource exceeds the effective threshold. */
+  isInefficient: boolean;
+  /** Latest matching resource payload summary, or `null` before a match. */
+  latest: NetworkEfficiencyEntry | null;
+  /** Configured threshold after Network Information API adjustments. */
+  effectiveMaxSizeInBytes: number;
+  /** Network effective type, or `null` when unsupported/unavailable. */
+  effectiveType: NetworkEffectiveType | null;
+  /** Whether this browser exposes resource timing entries. */
+  isSupported: boolean;
+}
+
+interface NetworkInformationLike {
+  effectiveType?: NetworkEffectiveType;
+  saveData?: boolean;
+}
+
+interface NavigatorWithConnection extends Navigator {
+  connection?: NetworkInformationLike;
+  mozConnection?: NetworkInformationLike;
+  webkitConnection?: NetworkInformationLike;
+}
+
+interface PerformanceObserverEntryListLike {
+  getEntries: () => PerformanceEntry[];
+}
+
+type PerformanceObserverCallbackLike = (
+  list: PerformanceObserverEntryListLike,
+  observer: PerformanceObserver,
+) => void;
+
+type PerformanceObserverConstructorLike = {
+  new (callback: PerformanceObserverCallbackLike): PerformanceObserver;
+  supportedEntryTypes?: readonly string[];
+};
+
+const DEFAULT_MAX_SIZE_IN_BYTES = 1024 * 500;
+
+const unsupportedState: UseNetworkEfficiencyReturn = {
+  lastPayloadSize: null,
+  isInefficient: false,
+  latest: null,
+  effectiveMaxSizeInBytes: DEFAULT_MAX_SIZE_IN_BYTES,
+  effectiveType: null,
+  isSupported: false,
+};
+
+function getNow(): number {
+  return typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+}
+
+function normalizeMaxSizeInBytes(maxSizeInBytes: number): number {
+  return Number.isFinite(maxSizeInBytes) && maxSizeInBytes >= 0
+    ? Math.floor(maxSizeInBytes)
+    : DEFAULT_MAX_SIZE_IN_BYTES;
+}
+
+function getConnection(): NetworkInformationLike | null {
+  if (typeof navigator === 'undefined') return null;
+
+  const nav = navigator as NavigatorWithConnection;
+  return nav.connection ?? nav.mozConnection ?? nav.webkitConnection ?? null;
+}
+
+function getEffectiveType(): NetworkEffectiveType | null {
+  return getConnection()?.effectiveType ?? null;
+}
+
+function getEffectiveMaxSizeInBytes(maxSizeInBytes: number): number {
+  const connection = getConnection();
+  const effectiveType = connection?.effectiveType;
+
+  if (effectiveType === 'slow-2g' || effectiveType === '2g') {
+    return Math.floor(maxSizeInBytes * 0.25);
+  }
+
+  if (effectiveType === '3g') {
+    return Math.floor(maxSizeInBytes * 0.5);
+  }
+
+  if (connection?.saveData) {
+    return Math.floor(maxSizeInBytes * 0.5);
+  }
+
+  return maxSizeInBytes;
+}
+
+function isResourceTiming(entry: PerformanceEntry): entry is PerformanceResourceTiming {
+  return entry.entryType === 'resource';
+}
+
+function supportsResourceTiming(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof performance !== 'undefined' &&
+    typeof performance.getEntriesByType === 'function'
+  );
+}
+
+function supportsResourceObserver(): boolean {
+  if (typeof window === 'undefined' || typeof PerformanceObserver === 'undefined') {
+    return false;
+  }
+
+  const Observer = PerformanceObserver as PerformanceObserverConstructorLike;
+  return (
+    Array.isArray(Observer.supportedEntryTypes) && Observer.supportedEntryTypes.includes('resource')
+  );
+}
+
+function matchesResourceFilter(
+  entry: PerformanceResourceTiming,
+  resourceFilter: NetworkResourceFilter | undefined,
+): boolean {
+  if (!resourceFilter) return true;
+
+  if (typeof resourceFilter === 'string') {
+    return entry.name.includes(resourceFilter);
+  }
+
+  if (resourceFilter instanceof RegExp) {
+    resourceFilter.lastIndex = 0;
+    return resourceFilter.test(entry.name);
+  }
+
+  return resourceFilter(entry);
+}
+
+function getPayloadSize(entry: PerformanceResourceTiming): number {
+  const sizes = [entry.transferSize, entry.encodedBodySize, entry.decodedBodySize];
+  const size = sizes.find((value) => Number.isFinite(value) && value > 0);
+  return size ?? 0;
+}
+
+function getResourceEntryKey(entry: PerformanceResourceTiming): string {
+  return `${entry.name}:${entry.startTime}:${entry.duration}:${entry.transferSize}:${entry.encodedBodySize}:${entry.decodedBodySize}`;
+}
+
+function toNetworkEfficiencyEntry(
+  entry: PerformanceResourceTiming,
+  effectiveMaxSizeInBytes: number,
+): NetworkEfficiencyEntry {
+  const payloadSize = getPayloadSize(entry);
+
+  return {
+    name: entry.name,
+    initiatorType: entry.initiatorType,
+    payloadSize,
+    transferSize: entry.transferSize,
+    encodedBodySize: entry.encodedBodySize,
+    decodedBodySize: entry.decodedBodySize,
+    effectiveMaxSizeInBytes,
+    effectiveType: getEffectiveType(),
+    isInefficient: payloadSize > effectiveMaxSizeInBytes,
+    startTime: entry.startTime,
+    duration: entry.duration,
+    timestamp: getNow(),
+  };
+}
+
+/**
+ * Monitors Resource Timing entries and flags payloads that are too large for
+ * the current network conditions.
+ *
+ * @example
+ * function ApiPayloadProbe() {
+ *   const { lastPayloadSize, isInefficient } = useNetworkEfficiency({
+ *     resourceFilter: '/api/v1/heavy-data',
+ *     maxSizeInBytes: 1024 * 500,
+ *     onWarning: (entry) => console.warn('Large payload', entry),
+ *   });
+ *
+ *   return <span>{isInefficient ? `${lastPayloadSize} bytes` : null}</span>;
+ * }
+ */
+export function useNetworkEfficiency(
+  options: UseNetworkEfficiencyOptions = {},
+): UseNetworkEfficiencyReturn {
+  const {
+    resourceFilter,
+    maxSizeInBytes = DEFAULT_MAX_SIZE_IN_BYTES,
+    onWarning,
+    enabled = true,
+  } = options;
+  const normalizedMaxSizeInBytes = normalizeMaxSizeInBytes(maxSizeInBytes);
+  const effectiveMaxSizeInBytes = useMemo(
+    () => getEffectiveMaxSizeInBytes(normalizedMaxSizeInBytes),
+    [normalizedMaxSizeInBytes],
+  );
+  const effectiveType = useMemo(() => getEffectiveType(), []);
+  const isSupported = supportsResourceTiming();
+  const [latest, setLatest] = useState<NetworkEfficiencyEntry | null>(null);
+  const processedEntryKeysRef = useRef(new Set<string>());
+  const resourceFilterRef = useRef(resourceFilter);
+  const effectiveMaxSizeInBytesRef = useRef(effectiveMaxSizeInBytes);
+  const onWarningRef = useRef(onWarning);
+
+  useEffect(() => {
+    resourceFilterRef.current = resourceFilter;
+    effectiveMaxSizeInBytesRef.current = effectiveMaxSizeInBytes;
+    onWarningRef.current = onWarning;
+  }, [effectiveMaxSizeInBytes, onWarning, resourceFilter]);
+
+  const handleEntry = useCallback((entry: PerformanceResourceTiming) => {
+    if (!matchesResourceFilter(entry, resourceFilterRef.current)) return;
+
+    const key = getResourceEntryKey(entry);
+    if (processedEntryKeysRef.current.has(key)) return;
+
+    processedEntryKeysRef.current.add(key);
+    const metric = toNetworkEfficiencyEntry(entry, effectiveMaxSizeInBytesRef.current);
+
+    setLatest(metric);
+
+    if (metric.isInefficient) {
+      onWarningRef.current?.(metric);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !isSupported) return;
+
+    for (const entry of performance.getEntriesByType('resource')) {
+      if (isResourceTiming(entry)) {
+        handleEntry(entry);
+      }
+    }
+
+    if (!supportsResourceObserver()) return;
+
+    const Observer = PerformanceObserver as PerformanceObserverConstructorLike;
+    const observer = new Observer((list) => {
+      for (const entry of list.getEntries()) {
+        if (isResourceTiming(entry)) {
+          handleEntry(entry);
+        }
+      }
+    });
+
+    observer.observe({
+      type: 'resource',
+      buffered: true,
+    } as PerformanceObserverInit);
+
+    return () => observer.disconnect();
+  }, [enabled, handleEntry, isSupported]);
+
+  if (!isSupported) {
+    return {
+      ...unsupportedState,
+      effectiveMaxSizeInBytes,
+      effectiveType,
+    };
+  }
+
+  return {
+    lastPayloadSize: latest?.payloadSize ?? null,
+    isInefficient: latest?.isInefficient ?? false,
+    latest,
+    effectiveMaxSizeInBytes,
+    effectiveType,
+    isSupported,
+  };
+}

--- a/src/hooks/useNetworkEfficiency/index.ts
+++ b/src/hooks/useNetworkEfficiency/index.ts
@@ -109,6 +109,7 @@ interface LatestNetworkResource {
 }
 
 const DEFAULT_MAX_SIZE_IN_BYTES = 1024 * 500;
+const MAX_TRACKED_RESOURCE_ENTRIES = 100;
 
 const unsupportedState: UseNetworkEfficiencyReturn = {
   lastPayloadSize: null,
@@ -225,6 +226,25 @@ function getPayloadSize(entry: PerformanceResourceTiming): number {
 
 function getResourceEntryKey(entry: PerformanceResourceTiming): string {
   return `${entry.name}:${entry.startTime}:${entry.duration}:${entry.transferSize}:${entry.encodedBodySize}:${entry.decodedBodySize}`;
+}
+
+function retainResourceEntry(
+  entries: Map<string, PerformanceResourceTiming>,
+  inefficientStates: Map<string, boolean>,
+  key: string,
+  entry: PerformanceResourceTiming,
+): void {
+  entries.delete(key);
+  entries.set(key, entry);
+
+  while (entries.size > MAX_TRACKED_RESOURCE_ENTRIES) {
+    const oldestKey = entries.keys().next().value;
+
+    if (oldestKey === undefined) return;
+
+    entries.delete(oldestKey);
+    inefficientStates.delete(oldestKey);
+  }
 }
 
 function toNetworkEfficiencyEntry(
@@ -348,7 +368,7 @@ export function useNetworkEfficiency(
           },
     );
 
-    processedEntriesRef.current.set(key, entry);
+    retainResourceEntry(processedEntriesRef.current, entryInefficientStateRef.current, key, entry);
 
     const wasInefficient = entryInefficientStateRef.current.get(key) === true;
     entryInefficientStateRef.current.set(key, metric.isInefficient);

--- a/src/hooks/useNetworkEfficiency/index.ts
+++ b/src/hooks/useNetworkEfficiency/index.ts
@@ -234,6 +234,8 @@ function retainResourceEntry(
   key: string,
   entry: PerformanceResourceTiming,
 ): void {
+  if (entries.get(key) === entry) return;
+
   entries.delete(key);
   entries.set(key, entry);
 

--- a/src/hooks/useNetworkEfficiency/index.ts
+++ b/src/hooks/useNetworkEfficiency/index.ts
@@ -74,6 +74,8 @@ export interface UseNetworkEfficiencyReturn {
 interface NetworkInformationLike {
   effectiveType?: NetworkEffectiveType;
   saveData?: boolean;
+  addEventListener?: (type: 'change', listener: () => void) => void;
+  removeEventListener?: (type: 'change', listener: () => void) => void;
 }
 
 interface NavigatorWithConnection extends Navigator {
@@ -95,6 +97,11 @@ type PerformanceObserverConstructorLike = {
   new (callback: PerformanceObserverCallbackLike): PerformanceObserver;
   supportedEntryTypes?: readonly string[];
 };
+
+interface NetworkState {
+  effectiveMaxSizeInBytes: number;
+  effectiveType: NetworkEffectiveType | null;
+}
 
 const DEFAULT_MAX_SIZE_IN_BYTES = 1024 * 500;
 
@@ -126,12 +133,10 @@ function getConnection(): NetworkInformationLike | null {
   return nav.connection ?? nav.mozConnection ?? nav.webkitConnection ?? null;
 }
 
-function getEffectiveType(): NetworkEffectiveType | null {
-  return getConnection()?.effectiveType ?? null;
-}
-
-function getEffectiveMaxSizeInBytes(maxSizeInBytes: number): number {
-  const connection = getConnection();
+function getEffectiveMaxSizeInBytes(
+  maxSizeInBytes: number,
+  connection: NetworkInformationLike | null = getConnection(),
+): number {
   const effectiveType = connection?.effectiveType;
 
   if (effectiveType === 'slow-2g' || effectiveType === '2g') {
@@ -147,6 +152,15 @@ function getEffectiveMaxSizeInBytes(maxSizeInBytes: number): number {
   }
 
   return maxSizeInBytes;
+}
+
+function getNetworkState(maxSizeInBytes: number): NetworkState {
+  const connection = getConnection();
+
+  return {
+    effectiveMaxSizeInBytes: getEffectiveMaxSizeInBytes(maxSizeInBytes, connection),
+    effectiveType: connection?.effectiveType ?? null,
+  };
 }
 
 function isResourceTiming(entry: PerformanceEntry): entry is PerformanceResourceTiming {
@@ -190,6 +204,14 @@ function matchesResourceFilter(
   return resourceFilter(entry);
 }
 
+function getResourceFilterKey(resourceFilter: NetworkResourceFilter | undefined): unknown {
+  if (resourceFilter instanceof RegExp) {
+    return `regexp:${resourceFilter.source}/${resourceFilter.flags}`;
+  }
+
+  return resourceFilter;
+}
+
 function getPayloadSize(entry: PerformanceResourceTiming): number {
   const sizes = [entry.transferSize, entry.encodedBodySize, entry.decodedBodySize];
   const size = sizes.find((value) => Number.isFinite(value) && value > 0);
@@ -203,6 +225,7 @@ function getResourceEntryKey(entry: PerformanceResourceTiming): string {
 function toNetworkEfficiencyEntry(
   entry: PerformanceResourceTiming,
   effectiveMaxSizeInBytes: number,
+  effectiveType: NetworkEffectiveType | null,
 ): NetworkEfficiencyEntry {
   const payloadSize = getPayloadSize(entry);
 
@@ -214,12 +237,31 @@ function toNetworkEfficiencyEntry(
     encodedBodySize: entry.encodedBodySize,
     decodedBodySize: entry.decodedBodySize,
     effectiveMaxSizeInBytes,
-    effectiveType: getEffectiveType(),
+    effectiveType,
     isInefficient: payloadSize > effectiveMaxSizeInBytes,
     startTime: entry.startTime,
     duration: entry.duration,
     timestamp: getNow(),
   };
+}
+
+function areSameNetworkEfficiencyEntry(
+  current: NetworkEfficiencyEntry | null,
+  next: NetworkEfficiencyEntry,
+): boolean {
+  return (
+    current?.name === next.name &&
+    current.initiatorType === next.initiatorType &&
+    current.payloadSize === next.payloadSize &&
+    current.transferSize === next.transferSize &&
+    current.encodedBodySize === next.encodedBodySize &&
+    current.decodedBodySize === next.decodedBodySize &&
+    current.effectiveMaxSizeInBytes === next.effectiveMaxSizeInBytes &&
+    current.effectiveType === next.effectiveType &&
+    current.isInefficient === next.isInefficient &&
+    current.startTime === next.startTime &&
+    current.duration === next.duration
+  );
 }
 
 /**
@@ -247,37 +289,58 @@ export function useNetworkEfficiency(
     enabled = true,
   } = options;
   const normalizedMaxSizeInBytes = normalizeMaxSizeInBytes(maxSizeInBytes);
-  const effectiveMaxSizeInBytes = useMemo(
-    () => getEffectiveMaxSizeInBytes(normalizedMaxSizeInBytes),
-    [normalizedMaxSizeInBytes],
+  const [networkState, setNetworkState] = useState<NetworkState>(() =>
+    getNetworkState(normalizedMaxSizeInBytes),
   );
-  const effectiveType = useMemo(() => getEffectiveType(), []);
+  const { effectiveMaxSizeInBytes, effectiveType } = networkState;
+  const resourceFilterKey = getResourceFilterKey(resourceFilter);
   const isSupported = supportsResourceTiming();
   const [latest, setLatest] = useState<NetworkEfficiencyEntry | null>(null);
   const processedEntryKeysRef = useRef(new Set<string>());
   const resourceFilterRef = useRef(resourceFilter);
   const effectiveMaxSizeInBytesRef = useRef(effectiveMaxSizeInBytes);
+  const effectiveTypeRef = useRef(effectiveType);
   const onWarningRef = useRef(onWarning);
+
+  useEffect(() => {
+    const updateNetworkState = () => {
+      setNetworkState(getNetworkState(normalizedMaxSizeInBytes));
+    };
+    const connection = getConnection();
+
+    updateNetworkState();
+    connection?.addEventListener?.('change', updateNetworkState);
+
+    return () => {
+      connection?.removeEventListener?.('change', updateNetworkState);
+    };
+  }, [normalizedMaxSizeInBytes]);
 
   useEffect(() => {
     resourceFilterRef.current = resourceFilter;
     effectiveMaxSizeInBytesRef.current = effectiveMaxSizeInBytes;
+    effectiveTypeRef.current = effectiveType;
     onWarningRef.current = onWarning;
-  }, [effectiveMaxSizeInBytes, onWarning, resourceFilter]);
+  }, [effectiveMaxSizeInBytes, effectiveType, onWarning, resourceFilter]);
 
-  const handleEntry = useCallback((entry: PerformanceResourceTiming) => {
+  const handleEntry = useCallback((entry: PerformanceResourceTiming, notify = true) => {
     if (!matchesResourceFilter(entry, resourceFilterRef.current)) return;
 
     const key = getResourceEntryKey(entry);
-    if (processedEntryKeysRef.current.has(key)) return;
+    const hasProcessedEntry = processedEntryKeysRef.current.has(key);
+    const metric = toNetworkEfficiencyEntry(
+      entry,
+      effectiveMaxSizeInBytesRef.current,
+      effectiveTypeRef.current,
+    );
 
-    processedEntryKeysRef.current.add(key);
-    const metric = toNetworkEfficiencyEntry(entry, effectiveMaxSizeInBytesRef.current);
+    setLatest((current) => (areSameNetworkEfficiencyEntry(current, metric) ? current : metric));
 
-    setLatest(metric);
-
-    if (metric.isInefficient) {
+    if (notify && !hasProcessedEntry && metric.isInefficient) {
+      processedEntryKeysRef.current.add(key);
       onWarningRef.current?.(metric);
+    } else if (!hasProcessedEntry) {
+      processedEntryKeysRef.current.add(key);
     }
   }, []);
 
@@ -307,10 +370,13 @@ export function useNetworkEfficiency(
     } as PerformanceObserverInit);
 
     return () => observer.disconnect();
-  }, [enabled, handleEntry, isSupported]);
+  }, [enabled, handleEntry, isSupported, resourceFilterKey]);
 
   const currentLatest = useMemo<NetworkEfficiencyEntry | null>(() => {
     if (!latest) return null;
+    if (!matchesResourceFilter(latest as unknown as PerformanceResourceTiming, resourceFilter)) {
+      return null;
+    }
 
     return {
       ...latest,
@@ -318,7 +384,7 @@ export function useNetworkEfficiency(
       effectiveType,
       isInefficient: latest.payloadSize > effectiveMaxSizeInBytes,
     };
-  }, [effectiveMaxSizeInBytes, effectiveType, latest]);
+  }, [effectiveMaxSizeInBytes, effectiveType, latest, resourceFilter]);
 
   if (!isSupported) {
     return {

--- a/src/hooks/useNetworkEfficiency/index.ts
+++ b/src/hooks/useNetworkEfficiency/index.ts
@@ -103,6 +103,11 @@ interface NetworkState {
   effectiveType: NetworkEffectiveType | null;
 }
 
+interface LatestNetworkResource {
+  source: PerformanceResourceTiming;
+  metric: NetworkEfficiencyEntry;
+}
+
 const DEFAULT_MAX_SIZE_IN_BYTES = 1024 * 500;
 
 const unsupportedState: UseNetworkEfficiencyReturn = {
@@ -295,7 +300,7 @@ export function useNetworkEfficiency(
   const { effectiveMaxSizeInBytes, effectiveType } = networkState;
   const resourceFilterKey = getResourceFilterKey(resourceFilter);
   const isSupported = supportsResourceTiming();
-  const [latest, setLatest] = useState<NetworkEfficiencyEntry | null>(null);
+  const [latest, setLatest] = useState<LatestNetworkResource | null>(null);
   const processedEntryKeysRef = useRef(new Set<string>());
   const resourceFilterRef = useRef(resourceFilter);
   const effectiveMaxSizeInBytesRef = useRef(effectiveMaxSizeInBytes);
@@ -334,7 +339,14 @@ export function useNetworkEfficiency(
       effectiveTypeRef.current,
     );
 
-    setLatest((current) => (areSameNetworkEfficiencyEntry(current, metric) ? current : metric));
+    setLatest((current) =>
+      areSameNetworkEfficiencyEntry(current?.metric ?? null, metric)
+        ? current
+        : {
+            source: entry,
+            metric,
+          },
+    );
 
     if (notify && !hasProcessedEntry && metric.isInefficient) {
       processedEntryKeysRef.current.add(key);
@@ -374,15 +386,15 @@ export function useNetworkEfficiency(
 
   const currentLatest = useMemo<NetworkEfficiencyEntry | null>(() => {
     if (!latest) return null;
-    if (!matchesResourceFilter(latest as unknown as PerformanceResourceTiming, resourceFilter)) {
+    if (!matchesResourceFilter(latest.source, resourceFilter)) {
       return null;
     }
 
     return {
-      ...latest,
+      ...latest.metric,
       effectiveMaxSizeInBytes,
       effectiveType,
-      isInefficient: latest.payloadSize > effectiveMaxSizeInBytes,
+      isInefficient: latest.metric.payloadSize > effectiveMaxSizeInBytes,
     };
   }, [effectiveMaxSizeInBytes, effectiveType, latest, resourceFilter]);
 

--- a/src/hooks/useNetworkEfficiency/index.ts
+++ b/src/hooks/useNetworkEfficiency/index.ts
@@ -309,6 +309,17 @@ export function useNetworkEfficiency(
     return () => observer.disconnect();
   }, [enabled, handleEntry, isSupported]);
 
+  const currentLatest = useMemo<NetworkEfficiencyEntry | null>(() => {
+    if (!latest) return null;
+
+    return {
+      ...latest,
+      effectiveMaxSizeInBytes,
+      effectiveType,
+      isInefficient: latest.payloadSize > effectiveMaxSizeInBytes,
+    };
+  }, [effectiveMaxSizeInBytes, effectiveType, latest]);
+
   if (!isSupported) {
     return {
       ...unsupportedState,
@@ -318,9 +329,9 @@ export function useNetworkEfficiency(
   }
 
   return {
-    lastPayloadSize: latest?.payloadSize ?? null,
-    isInefficient: latest?.isInefficient ?? false,
-    latest,
+    lastPayloadSize: currentLatest?.payloadSize ?? null,
+    isInefficient: currentLatest?.isInefficient ?? false,
+    latest: currentLatest,
     effectiveMaxSizeInBytes,
     effectiveType,
     isSupported,

--- a/src/hooks/useNetworkEfficiency/index.ts
+++ b/src/hooks/useNetworkEfficiency/index.ts
@@ -301,7 +301,8 @@ export function useNetworkEfficiency(
   const resourceFilterKey = getResourceFilterKey(resourceFilter);
   const isSupported = supportsResourceTiming();
   const [latest, setLatest] = useState<LatestNetworkResource | null>(null);
-  const processedEntryKeysRef = useRef(new Set<string>());
+  const processedEntriesRef = useRef(new Map<string, PerformanceResourceTiming>());
+  const entryInefficientStateRef = useRef(new Map<string, boolean>());
   const resourceFilterRef = useRef(resourceFilter);
   const effectiveMaxSizeInBytesRef = useRef(effectiveMaxSizeInBytes);
   const effectiveTypeRef = useRef(effectiveType);
@@ -332,7 +333,6 @@ export function useNetworkEfficiency(
     if (!matchesResourceFilter(entry, resourceFilterRef.current)) return;
 
     const key = getResourceEntryKey(entry);
-    const hasProcessedEntry = processedEntryKeysRef.current.has(key);
     const metric = toNetworkEfficiencyEntry(
       entry,
       effectiveMaxSizeInBytesRef.current,
@@ -348,11 +348,13 @@ export function useNetworkEfficiency(
           },
     );
 
-    if (notify && !hasProcessedEntry && metric.isInefficient) {
-      processedEntryKeysRef.current.add(key);
+    processedEntriesRef.current.set(key, entry);
+
+    const wasInefficient = entryInefficientStateRef.current.get(key) === true;
+    entryInefficientStateRef.current.set(key, metric.isInefficient);
+
+    if (notify && metric.isInefficient && !wasInefficient) {
       onWarningRef.current?.(metric);
-    } else if (!hasProcessedEntry) {
-      processedEntryKeysRef.current.add(key);
     }
   }, []);
 
@@ -383,6 +385,21 @@ export function useNetworkEfficiency(
 
     return () => observer.disconnect();
   }, [enabled, handleEntry, isSupported, resourceFilterKey]);
+
+  useEffect(() => {
+    if (!enabled || !isSupported) return;
+
+    for (const entry of processedEntriesRef.current.values()) {
+      handleEntry(entry);
+    }
+  }, [
+    effectiveMaxSizeInBytes,
+    effectiveType,
+    enabled,
+    handleEntry,
+    isSupported,
+    resourceFilterKey,
+  ]);
 
   const currentLatest = useMemo<NetworkEfficiencyEntry | null>(() => {
     if (!latest) return null;

--- a/src/hooks/useNetworkEfficiency/useNetworkEfficiency.test.tsx
+++ b/src/hooks/useNetworkEfficiency/useNetworkEfficiency.test.tsx
@@ -1,0 +1,313 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useNetworkEfficiency } from './index';
+
+type ObserverCallback = (
+  list: { getEntries: () => PerformanceEntry[] },
+  observer: PerformanceObserver,
+) => void;
+
+const originalPerformanceObserver = globalThis.PerformanceObserver;
+const originalNavigatorConnectionDescriptor = Object.getOwnPropertyDescriptor(
+  Navigator.prototype,
+  'connection',
+);
+
+class MockPerformanceObserver {
+  static supportedEntryTypes = ['resource'];
+  static callback: ObserverCallback | null = null;
+  static observe = vi.fn();
+  static disconnect = vi.fn();
+
+  constructor(callback: ObserverCallback) {
+    MockPerformanceObserver.callback = callback;
+  }
+
+  observe(options: PerformanceObserverInit): void {
+    MockPerformanceObserver.observe(options);
+  }
+
+  disconnect(): void {
+    MockPerformanceObserver.disconnect();
+  }
+}
+
+function mockPerformanceObserver(entryTypes: string[] = ['resource']): void {
+  MockPerformanceObserver.supportedEntryTypes = entryTypes;
+  globalThis.PerformanceObserver = MockPerformanceObserver as unknown as typeof PerformanceObserver;
+}
+
+function mockResourceEntries(entries: PerformanceResourceTiming[]): void {
+  vi.spyOn(performance, 'getEntriesByType').mockImplementation((type: string) =>
+    type === 'resource' ? entries : [],
+  );
+}
+
+function mockConnection(effectiveType?: string, saveData = false): void {
+  Object.defineProperty(navigator, 'connection', {
+    configurable: true,
+    value: effectiveType ? { effectiveType, saveData } : undefined,
+  });
+}
+
+function createResourceEntry(
+  overrides: Partial<PerformanceResourceTiming> & { name: string },
+): PerformanceResourceTiming {
+  return {
+    name: overrides.name,
+    entryType: 'resource',
+    startTime: overrides.startTime ?? 0,
+    duration: overrides.duration ?? 20,
+    initiatorType: overrides.initiatorType ?? 'fetch',
+    nextHopProtocol: '',
+    workerStart: 0,
+    redirectStart: 0,
+    redirectEnd: 0,
+    fetchStart: 0,
+    domainLookupStart: 0,
+    domainLookupEnd: 0,
+    connectStart: 0,
+    connectEnd: 0,
+    secureConnectionStart: 0,
+    requestStart: 0,
+    responseStart: 0,
+    firstInterimResponseStart: 0,
+    finalResponseHeadersStart: 0,
+    responseEnd: 0,
+    transferSize: overrides.transferSize ?? 0,
+    encodedBodySize: overrides.encodedBodySize ?? 0,
+    decodedBodySize: overrides.decodedBodySize ?? 0,
+    responseStatus: 200,
+    renderBlockingStatus: 'non-blocking',
+    serverTiming: [],
+    contentType: '',
+    deliveryType: '',
+    toJSON: () => ({}),
+  } as PerformanceResourceTiming;
+}
+
+function emitResource(entry: PerformanceResourceTiming): void {
+  act(() => {
+    MockPerformanceObserver.callback?.(
+      {
+        getEntries: () => [entry],
+      },
+      {} as PerformanceObserver,
+    );
+  });
+}
+
+describe('useNetworkEfficiency', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    MockPerformanceObserver.callback = null;
+    mockPerformanceObserver();
+    mockResourceEntries([]);
+    mockConnection(undefined);
+  });
+
+  afterEach(() => {
+    globalThis.PerformanceObserver = originalPerformanceObserver;
+    vi.unstubAllGlobals();
+
+    if (originalNavigatorConnectionDescriptor) {
+      Object.defineProperty(navigator, 'connection', originalNavigatorConnectionDescriptor);
+    } else {
+      Reflect.deleteProperty(navigator, 'connection');
+    }
+  });
+
+  it('reads existing resource entries and matches a string resource filter', () => {
+    const onWarning = vi.fn();
+    mockResourceEntries([
+      createResourceEntry({
+        name: 'https://example.com/api/v1/light-data',
+        transferSize: 128_000,
+      }),
+      createResourceEntry({
+        name: 'https://example.com/api/v1/heavy-data',
+        transferSize: 700_000,
+        startTime: 10,
+      }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useNetworkEfficiency({
+        resourceFilter: '/api/v1/heavy-data',
+        maxSizeInBytes: 500_000,
+        onWarning,
+      }),
+    );
+
+    expect(result.current.lastPayloadSize).toBe(700_000);
+    expect(result.current.isInefficient).toBe(true);
+    expect(result.current.latest).toMatchObject({
+      name: 'https://example.com/api/v1/heavy-data',
+      transferSize: 700_000,
+      payloadSize: 700_000,
+      effectiveMaxSizeInBytes: 500_000,
+    });
+    expect(onWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'https://example.com/api/v1/heavy-data',
+        isInefficient: true,
+      }),
+    );
+  });
+
+  it('matches regex resource filters from observed resource entries', () => {
+    const { result } = renderHook(() =>
+      useNetworkEfficiency({
+        resourceFilter: /\/api\/v\d+\/heavy-data/,
+        maxSizeInBytes: 500_000,
+      }),
+    );
+
+    emitResource(
+      createResourceEntry({
+        name: 'https://example.com/api/v2/heavy-data?cursor=1',
+        transferSize: 550_000,
+        startTime: 20,
+      }),
+    );
+
+    expect(MockPerformanceObserver.observe).toHaveBeenCalledWith({
+      type: 'resource',
+      buffered: true,
+    });
+    expect(result.current.lastPayloadSize).toBe(550_000);
+    expect(result.current.isInefficient).toBe(true);
+  });
+
+  it('falls back from transferSize to encodedBodySize and decodedBodySize', () => {
+    mockResourceEntries([
+      createResourceEntry({
+        name: '/api/v1/compressed',
+        transferSize: 0,
+        encodedBodySize: 300_000,
+        decodedBodySize: 900_000,
+      }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useNetworkEfficiency({
+        resourceFilter: '/api/v1/compressed',
+        maxSizeInBytes: 250_000,
+      }),
+    );
+
+    expect(result.current.lastPayloadSize).toBe(300_000);
+    expect(result.current.latest).toMatchObject({
+      transferSize: 0,
+      encodedBodySize: 300_000,
+      decodedBodySize: 900_000,
+    });
+  });
+
+  it('uses decodedBodySize when other byte sizes are unavailable', () => {
+    mockResourceEntries([
+      createResourceEntry({
+        name: '/api/v1/decoded-only',
+        transferSize: 0,
+        encodedBodySize: 0,
+        decodedBodySize: 350_000,
+      }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useNetworkEfficiency({
+        resourceFilter: '/api/v1/decoded-only',
+        maxSizeInBytes: 300_000,
+      }),
+    );
+
+    expect(result.current.lastPayloadSize).toBe(350_000);
+    expect(result.current.isInefficient).toBe(true);
+  });
+
+  it('lowers the threshold on 3g connections', () => {
+    mockConnection('3g');
+    mockResourceEntries([
+      createResourceEntry({
+        name: '/api/v1/mobile-data',
+        transferSize: 300_000,
+      }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useNetworkEfficiency({
+        resourceFilter: '/api/v1/mobile-data',
+        maxSizeInBytes: 500_000,
+      }),
+    );
+
+    expect(result.current.effectiveType).toBe('3g');
+    expect(result.current.effectiveMaxSizeInBytes).toBe(250_000);
+    expect(result.current.isInefficient).toBe(true);
+  });
+
+  it('lowers the threshold more aggressively on slow-2g connections', () => {
+    mockConnection('slow-2g');
+
+    const { result } = renderHook(() =>
+      useNetworkEfficiency({
+        maxSizeInBytes: 400_000,
+      }),
+    );
+
+    expect(result.current.effectiveType).toBe('slow-2g');
+    expect(result.current.effectiveMaxSizeInBytes).toBe(100_000);
+  });
+
+  it('gracefully degrades when Network Information API is unavailable', () => {
+    mockResourceEntries([
+      createResourceEntry({
+        name: '/api/v1/heavy-data',
+        transferSize: 450_000,
+      }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useNetworkEfficiency({
+        resourceFilter: '/api/v1/heavy-data',
+        maxSizeInBytes: 500_000,
+      }),
+    );
+
+    expect(result.current.effectiveType).toBeNull();
+    expect(result.current.effectiveMaxSizeInBytes).toBe(500_000);
+    expect(result.current.isInefficient).toBe(false);
+  });
+
+  it('does not observe or scan when disabled', () => {
+    mockResourceEntries([
+      createResourceEntry({
+        name: '/api/v1/heavy-data',
+        transferSize: 700_000,
+      }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useNetworkEfficiency({
+        enabled: false,
+        resourceFilter: '/api/v1/heavy-data',
+      }),
+    );
+
+    expect(result.current.lastPayloadSize).toBeNull();
+    expect(MockPerformanceObserver.observe).not.toHaveBeenCalled();
+  });
+
+  it('returns unsupported state when resource timing is unavailable', () => {
+    vi.stubGlobal('performance', {
+      now: () => 0,
+    });
+
+    const { result } = renderHook(() => useNetworkEfficiency());
+
+    expect(result.current.isSupported).toBe(false);
+    expect(result.current.lastPayloadSize).toBeNull();
+    expect(MockPerformanceObserver.observe).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useNetworkEfficiency/useNetworkEfficiency.test.tsx
+++ b/src/hooks/useNetworkEfficiency/useNetworkEfficiency.test.tsx
@@ -531,6 +531,48 @@ describe('useNetworkEfficiency', () => {
     );
   });
 
+  it('retains only the most recent resources for threshold re-evaluation', () => {
+    const onWarning = vi.fn();
+    const { rerender } = renderHook(
+      ({ maxSizeInBytes }) =>
+        useNetworkEfficiency({
+          maxSizeInBytes,
+          onWarning,
+        }),
+      {
+        initialProps: {
+          maxSizeInBytes: 500_000,
+        },
+      },
+    );
+
+    for (let index = 0; index < 101; index += 1) {
+      emitResource(
+        createResourceEntry({
+          name: `/api/v1/resource-${index}`,
+          startTime: index,
+          transferSize: 300_000,
+        }),
+      );
+    }
+
+    rerender({
+      maxSizeInBytes: 250_000,
+    });
+
+    expect(onWarning).toHaveBeenCalledTimes(100);
+    expect(onWarning).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: '/api/v1/resource-0',
+      }),
+    );
+    expect(onWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: '/api/v1/resource-100',
+      }),
+    );
+  });
+
   it('does not observe or scan when disabled', () => {
     mockResourceEntries([
       createResourceEntry({

--- a/src/hooks/useNetworkEfficiency/useNetworkEfficiency.test.tsx
+++ b/src/hooks/useNetworkEfficiency/useNetworkEfficiency.test.tsx
@@ -336,6 +336,7 @@ describe('useNetworkEfficiency', () => {
   });
 
   it('recalculates the latest inefficient state when the threshold changes', () => {
+    const onWarning = vi.fn();
     mockResourceEntries([
       createResourceEntry({
         name: '/api/v1/configurable-data',
@@ -348,6 +349,7 @@ describe('useNetworkEfficiency', () => {
         useNetworkEfficiency({
           resourceFilter: '/api/v1/configurable-data',
           maxSizeInBytes,
+          onWarning,
         }),
       {
         initialProps: {
@@ -363,6 +365,7 @@ describe('useNetworkEfficiency', () => {
       isInefficient: false,
     });
     expect(result.current.isInefficient).toBe(false);
+    expect(onWarning).not.toHaveBeenCalled();
 
     rerender({
       maxSizeInBytes: 300_000,
@@ -375,6 +378,15 @@ describe('useNetworkEfficiency', () => {
       isInefficient: true,
     });
     expect(result.current.isInefficient).toBe(true);
+    expect(onWarning).toHaveBeenCalledTimes(1);
+    expect(onWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: '/api/v1/configurable-data',
+        payloadSize: 400_000,
+        effectiveMaxSizeInBytes: 300_000,
+        isInefficient: true,
+      }),
+    );
   });
 
   it('rescans existing entries and clears stale metrics when the resource filter changes', () => {
@@ -463,6 +475,53 @@ describe('useNetworkEfficiency', () => {
       effectiveMaxSizeInBytes: 250_000,
       isInefficient: true,
     });
+    expect(onWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        effectiveType: '3g',
+        effectiveMaxSizeInBytes: 250_000,
+        isInefficient: true,
+      }),
+    );
+  });
+
+  it('notifies when a network change makes a processed resource inefficient', () => {
+    const connection = mockConnection('4g');
+    const onWarning = vi.fn();
+    mockResourceEntries([
+      createResourceEntry({
+        name: '/api/v1/mobile-data',
+        transferSize: 300_000,
+      }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useNetworkEfficiency({
+        resourceFilter: '/api/v1/mobile-data',
+        maxSizeInBytes: 500_000,
+        onWarning,
+      }),
+    );
+
+    expect(result.current.latest).toMatchObject({
+      payloadSize: 300_000,
+      effectiveType: '4g',
+      effectiveMaxSizeInBytes: 500_000,
+      isInefficient: false,
+    });
+    expect(onWarning).not.toHaveBeenCalled();
+
+    act(() => {
+      connection!.effectiveType = '3g';
+      connection!.dispatchChange();
+    });
+
+    expect(result.current.latest).toMatchObject({
+      payloadSize: 300_000,
+      effectiveType: '3g',
+      effectiveMaxSizeInBytes: 250_000,
+      isInefficient: true,
+    });
+    expect(onWarning).toHaveBeenCalledTimes(1);
     expect(onWarning).toHaveBeenCalledWith(
       expect.objectContaining({
         effectiveType: '3g',

--- a/src/hooks/useNetworkEfficiency/useNetworkEfficiency.test.tsx
+++ b/src/hooks/useNetworkEfficiency/useNetworkEfficiency.test.tsx
@@ -51,7 +51,10 @@ function mockResourceEntries(entries: PerformanceResourceTiming[]): void {
   );
 }
 
-function mockConnection(effectiveType?: string, saveData = false): MockNetworkConnection | undefined {
+function mockConnection(
+  effectiveType?: string,
+  saveData = false,
+): MockNetworkConnection | undefined {
   const listeners = new Set<() => void>();
   const connection: MockNetworkConnection | undefined = effectiveType
     ? {

--- a/src/hooks/useNetworkEfficiency/useNetworkEfficiency.test.tsx
+++ b/src/hooks/useNetworkEfficiency/useNetworkEfficiency.test.tsx
@@ -7,6 +7,14 @@ type ObserverCallback = (
   observer: PerformanceObserver,
 ) => void;
 
+interface MockNetworkConnection {
+  effectiveType: string;
+  saveData: boolean;
+  addEventListener: (_type: 'change', listener: () => void) => void;
+  removeEventListener: (_type: 'change', listener: () => void) => void;
+  dispatchChange: () => void;
+}
+
 const originalPerformanceObserver = globalThis.PerformanceObserver;
 const originalNavigatorConnectionDescriptor = Object.getOwnPropertyDescriptor(
   Navigator.prototype,
@@ -43,11 +51,32 @@ function mockResourceEntries(entries: PerformanceResourceTiming[]): void {
   );
 }
 
-function mockConnection(effectiveType?: string, saveData = false): void {
+function mockConnection(effectiveType?: string, saveData = false): MockNetworkConnection | undefined {
+  const listeners = new Set<() => void>();
+  const connection: MockNetworkConnection | undefined = effectiveType
+    ? {
+        effectiveType,
+        saveData,
+        addEventListener: (_type: 'change', listener: () => void) => {
+          listeners.add(listener);
+        },
+        removeEventListener: (_type: 'change', listener: () => void) => {
+          listeners.delete(listener);
+        },
+        dispatchChange: () => {
+          for (const listener of listeners) {
+            listener();
+          }
+        },
+      }
+    : undefined;
+
   Object.defineProperty(navigator, 'connection', {
     configurable: true,
-    value: effectiveType ? { effectiveType, saveData } : undefined,
+    value: connection,
   });
+
+  return connection;
 }
 
 function createResourceEntry(
@@ -320,6 +349,101 @@ describe('useNetworkEfficiency', () => {
       isInefficient: true,
     });
     expect(result.current.isInefficient).toBe(true);
+  });
+
+  it('rescans existing entries and clears stale metrics when the resource filter changes', () => {
+    mockResourceEntries([
+      createResourceEntry({
+        name: '/api/v1/accounts',
+        transferSize: 200_000,
+      }),
+      createResourceEntry({
+        name: '/api/v1/orders',
+        transferSize: 600_000,
+        startTime: 10,
+      }),
+    ]);
+
+    const { result, rerender } = renderHook(
+      ({ resourceFilter }) =>
+        useNetworkEfficiency({
+          resourceFilter,
+          maxSizeInBytes: 500_000,
+        }),
+      {
+        initialProps: {
+          resourceFilter: '/api/v1/accounts',
+        },
+      },
+    );
+
+    expect(result.current.latest).toMatchObject({
+      name: '/api/v1/accounts',
+      payloadSize: 200_000,
+      isInefficient: false,
+    });
+
+    rerender({
+      resourceFilter: '/api/v1/orders',
+    });
+
+    expect(result.current.latest).toMatchObject({
+      name: '/api/v1/orders',
+      payloadSize: 600_000,
+      isInefficient: true,
+    });
+
+    rerender({
+      resourceFilter: '/api/v1/missing',
+    });
+
+    expect(result.current.latest).toBeNull();
+    expect(result.current.lastPayloadSize).toBeNull();
+    expect(result.current.isInefficient).toBe(false);
+  });
+
+  it('updates thresholds for resources observed after the network changes', () => {
+    const connection = mockConnection('4g');
+    const onWarning = vi.fn();
+    const { result } = renderHook(() =>
+      useNetworkEfficiency({
+        resourceFilter: '/api/v1/mobile-data',
+        maxSizeInBytes: 500_000,
+        onWarning,
+      }),
+    );
+
+    expect(result.current.effectiveType).toBe('4g');
+    expect(result.current.effectiveMaxSizeInBytes).toBe(500_000);
+
+    act(() => {
+      connection!.effectiveType = '3g';
+      connection!.dispatchChange();
+    });
+
+    expect(result.current.effectiveType).toBe('3g');
+    expect(result.current.effectiveMaxSizeInBytes).toBe(250_000);
+
+    emitResource(
+      createResourceEntry({
+        name: '/api/v1/mobile-data',
+        transferSize: 300_000,
+      }),
+    );
+
+    expect(result.current.latest).toMatchObject({
+      payloadSize: 300_000,
+      effectiveType: '3g',
+      effectiveMaxSizeInBytes: 250_000,
+      isInefficient: true,
+    });
+    expect(onWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        effectiveType: '3g',
+        effectiveMaxSizeInBytes: 250_000,
+        isInefficient: true,
+      }),
+    );
   });
 
   it('does not observe or scan when disabled', () => {

--- a/src/hooks/useNetworkEfficiency/useNetworkEfficiency.test.tsx
+++ b/src/hooks/useNetworkEfficiency/useNetworkEfficiency.test.tsx
@@ -212,6 +212,29 @@ describe('useNetworkEfficiency', () => {
     expect(result.current.isInefficient).toBe(true);
   });
 
+  it('keeps callback resource filters matched against the source timing entry', () => {
+    mockResourceEntries([
+      createResourceEntry({
+        name: 'https://example.com/api/v1/heavy-data',
+        transferSize: 700_000,
+      }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useNetworkEfficiency({
+        resourceFilter: (entry) =>
+          entry.entryType === 'resource' && entry.name.includes('/api/v1/heavy-data'),
+        maxSizeInBytes: 500_000,
+      }),
+    );
+
+    expect(result.current.latest).toMatchObject({
+      name: 'https://example.com/api/v1/heavy-data',
+      payloadSize: 700_000,
+      isInefficient: true,
+    });
+  });
+
   it('falls back from transferSize to encodedBodySize and decodedBodySize', () => {
     mockResourceEntries([
       createResourceEntry({

--- a/src/hooks/useNetworkEfficiency/useNetworkEfficiency.test.tsx
+++ b/src/hooks/useNetworkEfficiency/useNetworkEfficiency.test.tsx
@@ -280,6 +280,48 @@ describe('useNetworkEfficiency', () => {
     expect(result.current.isInefficient).toBe(false);
   });
 
+  it('recalculates the latest inefficient state when the threshold changes', () => {
+    mockResourceEntries([
+      createResourceEntry({
+        name: '/api/v1/configurable-data',
+        transferSize: 400_000,
+      }),
+    ]);
+
+    const { result, rerender } = renderHook(
+      ({ maxSizeInBytes }) =>
+        useNetworkEfficiency({
+          resourceFilter: '/api/v1/configurable-data',
+          maxSizeInBytes,
+        }),
+      {
+        initialProps: {
+          maxSizeInBytes: 500_000,
+        },
+      },
+    );
+
+    expect(result.current.effectiveMaxSizeInBytes).toBe(500_000);
+    expect(result.current.latest).toMatchObject({
+      payloadSize: 400_000,
+      effectiveMaxSizeInBytes: 500_000,
+      isInefficient: false,
+    });
+    expect(result.current.isInefficient).toBe(false);
+
+    rerender({
+      maxSizeInBytes: 300_000,
+    });
+
+    expect(result.current.effectiveMaxSizeInBytes).toBe(300_000);
+    expect(result.current.latest).toMatchObject({
+      payloadSize: 400_000,
+      effectiveMaxSizeInBytes: 300_000,
+      isInefficient: true,
+    });
+    expect(result.current.isInefficient).toBe(true);
+  });
+
   it('does not observe or scan when disabled', () => {
     mockResourceEntries([
       createResourceEntry({

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,3 +72,12 @@ export type {
   IntersectionObserverMetrics,
   UseIntersectionObserverReturn,
 } from './hooks/useIntersectionObserver';
+
+export { useNetworkEfficiency } from './hooks/useNetworkEfficiency';
+export type {
+  NetworkEffectiveType,
+  NetworkEfficiencyEntry,
+  NetworkResourceFilter,
+  UseNetworkEfficiencyOptions,
+  UseNetworkEfficiencyReturn,
+} from './hooks/useNetworkEfficiency';

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,15 @@ export type { UseFpsOptions, UseFpsReturn } from './hooks/useFps';
 export { useMemoryStatus } from './hooks/useMemoryStatus';
 export type { UseMemoryStatusOptions, UseMemoryStatusReturn } from './hooks/useMemoryStatus';
 
+export { useNetworkEfficiency } from './hooks/useNetworkEfficiency';
+export type {
+  NetworkEfficiencyEntry,
+  NetworkEffectiveType,
+  NetworkResourceFilter,
+  UseNetworkEfficiencyOptions,
+  UseNetworkEfficiencyReturn,
+} from './hooks/useNetworkEfficiency';
+
 export { useDebouncedState } from './hooks/useDebouncedState';
 export type { DebouncedStateStats, UseDebouncedStateReturn } from './hooks/useDebouncedState';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,12 +81,3 @@ export type {
   IntersectionObserverMetrics,
   UseIntersectionObserverReturn,
 } from './hooks/useIntersectionObserver';
-
-export { useNetworkEfficiency } from './hooks/useNetworkEfficiency';
-export type {
-  NetworkEffectiveType,
-  NetworkEfficiencyEntry,
-  NetworkResourceFilter,
-  UseNetworkEfficiencyOptions,
-  UseNetworkEfficiencyReturn,
-} from './hooks/useNetworkEfficiency';

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -121,6 +121,18 @@
   padding: 0.5rem 0.6rem;
 }
 
+.hookList a {
+  color: inherit;
+  display: block;
+  text-decoration: none;
+}
+
+.hookList a:hover,
+.hookList a:focus-visible {
+  color: var(--ifm-color-primary);
+  text-decoration: underline;
+}
+
 [data-theme='dark'] .hero {
   background:
     linear-gradient(132deg, rgba(70, 211, 178, 0.18), rgba(234, 120, 54, 0.22)),

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,19 +5,22 @@ import type { ReactNode } from 'react';
 import styles from './index.module.css';
 
 const hooks = [
-  'useRenderTracker',
-  'useRenderBudget',
-  'usePerformanceMark',
-  'useComponentLifecycle',
-  'useMemoProfiling',
-  'useWebVitals',
-  'useINP',
-  'useCLS',
-  'useLongTasks',
-  'useMemoryStatus',
-  'useDebouncedState',
-  'useThrottledState',
-  'useIntersectionObserver',
+  { name: 'useRenderTracker', to: '/docs/hooks/use-render-tracker' },
+  { name: 'useAllocationTracker', to: '/docs/hooks/use-allocation-tracker' },
+  { name: 'useRenderBudget', to: '/docs/hooks/use-render-budget' },
+  { name: 'usePerformanceMark', to: '/docs/hooks/use-performance-mark' },
+  { name: 'useComponentLifecycle', to: '/docs/hooks/use-component-lifecycle' },
+  { name: 'useMemoProfiling', to: '/docs/hooks/use-memo-profiling' },
+  { name: 'useWebVitals', to: '/docs/hooks/use-web-vitals' },
+  { name: 'useINP', to: '/docs/hooks/use-inp' },
+  { name: 'useCLS', to: '/docs/hooks/use-cls' },
+  { name: 'useLongTasks', to: '/docs/hooks/use-long-tasks' },
+  { name: 'useFps', to: '/docs/hooks/use-fps' },
+  { name: 'useMemoryStatus', to: '/docs/hooks/use-memory-status' },
+  { name: 'useNetworkEfficiency', to: '/docs/hooks/use-network-efficiency' },
+  { name: 'useDebouncedState', to: '/docs/hooks/use-debounced-state' },
+  { name: 'useThrottledState', to: '/docs/hooks/use-throttled-state' },
+  { name: 'useIntersectionObserver', to: '/docs/hooks/use-intersection-observer' },
 ];
 
 export default function Home(): ReactNode {
@@ -59,7 +62,7 @@ export default function Home(): ReactNode {
           <Heading as="h2">What this docs site includes</Heading>
           <div className={styles.cardGrid}>
             <article className={styles.card}>
-              <h3>13 hook references</h3>
+              <h3>16 hook references</h3>
               <p>
                 Every hook has signature details, parameter and return tables, and copy-ready usage
                 examples.
@@ -84,8 +87,10 @@ export default function Home(): ReactNode {
         <section className={styles.hookListSection}>
           <Heading as="h2">Hook coverage</Heading>
           <ul className={styles.hookList}>
-            {hooks.map((hookName) => (
-              <li key={hookName}>{hookName}</li>
+            {hooks.map((hook) => (
+              <li key={hook.name}>
+                <Link to={hook.to}>{hook.name}</Link>
+              </li>
             ))}
           </ul>
         </section>


### PR DESCRIPTION
### Description
High latency isn't just a CPU issue; network overhead plays a massive role. We need a `useNetworkEfficiency` hook that monitors resource timing and payload sizes (using the Resource Timing API) associated with specific API calls, warning developers if the payload is poorly optimized for mobile network conditions.

## Proposed API
```typescript
const { lastPayloadSize, isInefficient } = useNetworkEfficiency({
  resourceFilter: '/api/v1/heavy-data',
  maxSizeInBytes: 1024 * 500, // 500KB warning threshold
  onWarning: (entry) => reportBloatedPayload(entry)
});
```

Implementation Details
1. Read from performance.getEntriesByType('resource').
2. Look at properties like transferSize, encodedBodySize, and decodedBodySize.
3. Read navigator.connection (Network Information API) if available to dynamically lower the threshold if the user is on a 3g or slow-2g connection.
Acceptance Criteria
• [ ] Filters and identifies network resources accurately based on strings or regex patterns.
• [ ] Successfully reads transferred byte sizes where supported by the browser security policy (requires Timing-Allow-Origin headers on cross-origin resources).
• [ ] Gracefully degrades on browsers lacking the Network Information API.