### PR TITLE
Feat: Add useIdleCallbackWorker for offloading heavy tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ npm install web-vitals
 | `useDebouncedState` | Debounced `useState` with render-skip profiling counters | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-debounced-state) |
 | `useThrottledState` | Throttled `useState` with dropped-update profiling counters | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-throttled-state) |
 | `useIntersectionObserver` | Lazy-loading visibility state plus first-visible and total-visible metrics | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-intersection-observer) |
+| `useIdleCallbackWorker` | Offload heavy tasks to an inline Web Worker with `requestIdleCallback` fallback | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-idle-callback-worker) |
 
 See the [docs overview](https://valyefimov.github.io/react-perf-hooks/docs/getting-started) for a complete reference.
 

--- a/docs/hooks/use-idle-callback-worker.mdx
+++ b/docs/hooks/use-idle-callback-worker.mdx
@@ -22,27 +22,27 @@ function useIdleCallbackWorker<TArgs extends unknown[], TResult>(
 
 ## Parameters
 
-| Name      | Type                             | Required | Description                                                                                                    |
-| --------- | -------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
+| Name      | Type                             | Required | Description                                                                                                 |
+| --------- | -------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
 | `task`    | `IdleWorkerTask<TArgs, TResult>` | Yes      | The work to offload. On the worker path it is stringified, so it **must be pure** and not close over scope. |
-| `options` | `UseIdleCallbackWorkerOptions`   | No       | Strategy and timing controls (see below).                                                                     |
+| `options` | `UseIdleCallbackWorkerOptions`   | No       | Strategy and timing controls (see below).                                                                   |
 
 ### Options
 
-| Name            | Type                             | Default  | Description                                                                                          |
-| --------------- | -------------------------------- | -------- | --------------------------------------------------------------------------------------------------- |
-| `strategy`      | `'auto' \| 'worker' \| 'idle'`   | `'auto'` | `auto` prefers a Worker and falls back to idle scheduling; `worker` forces a Worker; `idle` forces the main-thread path (closures allowed). |
-| `chunkBudgetMs` | `number`                         | `8`      | Deadline for a single idle chunk before yielding.                                                   |
-| `timeoutMs`     | `number`                         | `30000`  | Rejects a pending task after this many ms.                                                          |
+| Name            | Type                           | Default  | Description                                                                                                                                 |
+| --------------- | ------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `strategy`      | `'auto' \| 'worker' \| 'idle'` | `'auto'` | `auto` prefers a Worker and falls back to idle scheduling; `worker` forces a Worker; `idle` forces the main-thread path (closures allowed). |
+| `chunkBudgetMs` | `number`                       | `8`      | Deadline for a single idle chunk before yielding.                                                                                           |
+| `timeoutMs`     | `number`                       | `30000`  | Rejects a pending task after this many ms.                                                                                                  |
 
 ## Return value
 
-| Field     | Type                            | Description                                             |
-| --------- | ------------------------------- | ------------------------------------------------------- |
+| Field     | Type                                   | Description                                                       |
+| --------- | -------------------------------------- | ----------------------------------------------------------------- |
 | `execute` | `(...args: TArgs) => Promise<TResult>` | Runs the task off the critical path and resolves with its result. |
-| `loading` | `boolean`                       | Whether a task is currently in flight.                  |
-| `result`  | `TResult \| null`               | Most recent successful result, or `null` before first run. |
-| `error`   | `Error \| null`                 | Most recent error, or `null` when the last run succeeded. |
+| `loading` | `boolean`                              | Whether a task is currently in flight.                            |
+| `result`  | `TResult \| null`                      | Most recent successful result, or `null` before first run.        |
+| `error`   | `Error \| null`                        | Most recent error, or `null` when the last run succeeded.         |
 
 ## Live interactive demo (StackBlitz)
 

--- a/docs/hooks/use-idle-callback-worker.mdx
+++ b/docs/hooks/use-idle-callback-worker.mdx
@@ -1,0 +1,88 @@
+---
+title: useIdleCallbackWorker
+description: Offload heavy tasks off the main thread with an inline Web Worker and requestIdleCallback fallback.
+---
+
+import StackBlitzEmbed from '@site/src/components/StackBlitzEmbed';
+
+## Description and use case
+
+`useIdleCallbackWorker` runs an expensive, synchronous task off the critical rendering path so it never freezes the UI thread or wrecks INP. It prefers an inline Web Worker (real parallelism, built from the task's source via a `Blob` URL) and transparently falls back to cooperative `requestIdleCallback` scheduling when Workers are unavailable — including during SSR.
+
+Reach for it when a handler processes 10,000+ array items, runs heavy filtering, or does math-heavy work that would otherwise block interaction.
+
+## API signature
+
+```ts
+function useIdleCallbackWorker<TArgs extends unknown[], TResult>(
+  task: IdleWorkerTask<TArgs, TResult>,
+  options?: UseIdleCallbackWorkerOptions,
+): UseIdleCallbackWorkerReturn<TArgs, TResult>;
+```
+
+## Parameters
+
+| Name      | Type                             | Required | Description                                                                                                    |
+| --------- | -------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
+| `task`    | `IdleWorkerTask<TArgs, TResult>` | Yes      | The work to offload. On the worker path it is stringified, so it **must be pure** and not close over scope. |
+| `options` | `UseIdleCallbackWorkerOptions`   | No       | Strategy and timing controls (see below).                                                                     |
+
+### Options
+
+| Name            | Type                             | Default  | Description                                                                                          |
+| --------------- | -------------------------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `strategy`      | `'auto' \| 'worker' \| 'idle'`   | `'auto'` | `auto` prefers a Worker and falls back to idle scheduling; `worker` forces a Worker; `idle` forces the main-thread path (closures allowed). |
+| `chunkBudgetMs` | `number`                         | `8`      | Deadline for a single idle chunk before yielding.                                                   |
+| `timeoutMs`     | `number`                         | `30000`  | Rejects a pending task after this many ms.                                                          |
+
+## Return value
+
+| Field     | Type                            | Description                                             |
+| --------- | ------------------------------- | ------------------------------------------------------- |
+| `execute` | `(...args: TArgs) => Promise<TResult>` | Runs the task off the critical path and resolves with its result. |
+| `loading` | `boolean`                       | Whether a task is currently in flight.                  |
+| `result`  | `TResult \| null`               | Most recent successful result, or `null` before first run. |
+| `error`   | `Error \| null`                 | Most recent error, or `null` when the last run succeeded. |
+
+## Live interactive demo (StackBlitz)
+
+<StackBlitzEmbed
+  title="useIdleCallbackWorker demo"
+  src="https://stackblitz.com/github/valyefimov/react-perf-hooks/tree/main/examples/stackblitz/hooks-playground?file=src/App.tsx&embed=1&view=preview&startScript=dev&demo=useIdleCallbackWorker"
+  openHref="https://stackblitz.com/github/valyefimov/react-perf-hooks/tree/main/examples/stackblitz/hooks-playground?file=src/App.tsx&startScript=dev&demo=useIdleCallbackWorker"
+/>
+
+## Code example
+
+```tsx
+import { useIdleCallbackWorker } from 'react-perf-hooks';
+
+// Pure task — no closures, safe to run inside a Web Worker.
+function filterLargeDataset(rows: number[], min: number): number[] {
+  return rows.filter((value) => value >= min);
+}
+
+export function SearchPanel({ rows }: { rows: number[] }) {
+  const { execute, loading, result, error } = useIdleCallbackWorker(filterLargeDataset);
+
+  const handleSearch = async () => {
+    const filtered = await execute(rows, 5000);
+    console.log(`matched ${filtered.length} rows`);
+  };
+
+  return (
+    <div>
+      <button type="button" onClick={handleSearch} disabled={loading}>
+        {loading ? 'Working…' : 'Filter'}
+      </button>
+      {error && <p role="alert">Failed: {error.message}</p>}
+      {result && <p>Matched {result.length} rows</p>}
+    </div>
+  );
+}
+```
+
+## Companion article
+
+- [dev.to companion article](https://dev.to/search?q=useIdleCallbackWorker)
+- [Medium companion article](https://medium.com/search?q=useIdleCallbackWorker)

--- a/examples/stackblitz/hooks-playground/src/App.tsx
+++ b/examples/stackblitz/hooks-playground/src/App.tsx
@@ -3,6 +3,7 @@ import { UseCLSDemo } from './demos/useCLSDemo';
 import { UseComponentLifecycleDemo } from './demos/useComponentLifecycleDemo';
 import { UseDebouncedStateDemo } from './demos/useDebouncedStateDemo';
 import { UseFpsDemo } from './demos/useFpsDemo';
+import { UseIdleCallbackWorkerDemo } from './demos/useIdleCallbackWorkerDemo';
 import { UseINPDemo } from './demos/useINPDemo';
 import { UseIntersectionObserverDemo } from './demos/useIntersectionObserverDemo';
 import { UseLongTasksDemo } from './demos/useLongTasksDemo';
@@ -28,7 +29,8 @@ type DemoKey =
   | 'useFps'
   | 'useDebouncedState'
   | 'useThrottledState'
-  | 'useIntersectionObserver';
+  | 'useIntersectionObserver'
+  | 'useIdleCallbackWorker';
 
 const demos: Record<DemoKey, { label: string; Component: () => JSX.Element }> = {
   useRenderTracker: { label: 'useRenderTracker', Component: UseRenderTrackerDemo },
@@ -47,6 +49,10 @@ const demos: Record<DemoKey, { label: string; Component: () => JSX.Element }> = 
   useIntersectionObserver: {
     label: 'useIntersectionObserver',
     Component: UseIntersectionObserverDemo,
+  },
+  useIdleCallbackWorker: {
+    label: 'useIdleCallbackWorker',
+    Component: UseIdleCallbackWorkerDemo,
   },
 };
 

--- a/examples/stackblitz/hooks-playground/src/demos/useIdleCallbackWorkerDemo.tsx
+++ b/examples/stackblitz/hooks-playground/src/demos/useIdleCallbackWorkerDemo.tsx
@@ -1,0 +1,70 @@
+import { useMemo } from 'react';
+import { useIdleCallbackWorker } from 'react-perf-hooks';
+
+// Pure task — safe to stringify and run inside a Web Worker.
+function sumHeavy(rows: number[], min: number): { count: number; total: number } {
+  let count = 0;
+  let total = 0;
+  for (const value of rows) {
+    if (value >= min) {
+      count += 1;
+      total += value;
+    }
+  }
+  return { count, total };
+}
+
+export function UseIdleCallbackWorkerDemo() {
+  const rows = useMemo(
+    () => Array.from({ length: 200_000 }, (_, index) => (index * 7919) % 100_000),
+    [],
+  );
+  const { execute, loading, result, error } = useIdleCallbackWorker(sumHeavy);
+
+  const run = async () => {
+    try {
+      await execute(rows, 50_000);
+    } catch {
+      // surfaced via the error field below
+    }
+  };
+
+  return (
+    <section style={{ fontFamily: 'system-ui', maxWidth: 480 }}>
+      <p style={{ marginTop: 0 }}>
+        Filters and sums 200,000 numbers off the main thread. The button stays responsive because
+        the work runs in a Web Worker (or on idle time as a fallback).
+      </p>
+
+      <button
+        type="button"
+        onClick={run}
+        disabled={loading}
+        style={{
+          border: '1px solid #cbd5e1',
+          borderRadius: 8,
+          background: loading ? '#94a3b8' : '#0f172a',
+          color: '#ffffff',
+          padding: '8px 14px',
+          cursor: loading ? 'progress' : 'pointer',
+        }}
+      >
+        {loading ? 'Processing…' : 'Run heavy task'}
+      </button>
+
+      <div
+        style={{
+          display: 'grid',
+          gap: 4,
+          marginTop: 12,
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+        }}
+      >
+        <div>Loading: {String(loading)}</div>
+        <div>Matched: {result ? result.count : 'not yet'}</div>
+        <div>Total: {result ? result.total : 'not yet'}</div>
+        {error && <div style={{ color: '#dc2626' }}>Error: {error.message}</div>}
+      </div>
+    </section>
+  );
+}

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -24,6 +24,7 @@ const sidebars: SidebarsConfig = {
         'hooks/use-debounced-state',
         'hooks/use-throttled-state',
         'hooks/use-intersection-observer',
+        'hooks/use-idle-callback-worker',
       ],
     },
     {

--- a/src/hooks/useIdleCallbackWorker/index.ts
+++ b/src/hooks/useIdleCallbackWorker/index.ts
@@ -1,0 +1,245 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * A pure, serializable task. It must not close over outer scope because it may
+ * be stringified and re-instantiated inside a Web Worker where no closure state
+ * exists. Receives the same arguments passed to `execute`.
+ */
+export type IdleWorkerTask<TArgs extends unknown[], TResult> = (
+  ...args: TArgs
+) => TResult | Promise<TResult>;
+
+export type IdleWorkerStrategy = 'auto' | 'worker' | 'idle';
+
+export interface UseIdleCallbackWorkerOptions {
+  /**
+   * Execution strategy. `auto` prefers a Web Worker and falls back to
+   * `requestIdleCallback` chunking on the main thread. Defaults to `auto`.
+   */
+  strategy?: IdleWorkerStrategy;
+  /** Deadline in ms for a single idle chunk before yielding. Defaults to 8ms. */
+  chunkBudgetMs?: number;
+  /** Timeout in ms after which a pending task is rejected. Defaults to 30000ms. */
+  timeoutMs?: number;
+}
+
+export interface UseIdleCallbackWorkerReturn<TArgs extends unknown[], TResult> {
+  /** Runs the task off the critical path and resolves with its result. */
+  execute: (...args: TArgs) => Promise<TResult>;
+  /** Whether a task is currently in flight. */
+  loading: boolean;
+  /** The most recent successful result, or null before the first run. */
+  result: TResult | null;
+  /** The most recent error, or null when the last run succeeded. */
+  error: Error | null;
+}
+
+interface IdleDeadline {
+  didTimeout: boolean;
+  timeRemaining: () => number;
+}
+
+type RequestIdleCallback = (
+  callback: (deadline: IdleDeadline) => void,
+  options?: { timeout: number },
+) => number;
+
+const DEFAULT_CHUNK_BUDGET_MS = 8;
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+function supportsWorker(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof Worker !== 'undefined' &&
+    typeof Blob !== 'undefined' &&
+    typeof URL !== 'undefined' &&
+    typeof URL.createObjectURL === 'function'
+  );
+}
+
+function getRequestIdleCallback(): RequestIdleCallback {
+  if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
+    return window.requestIdleCallback.bind(window) as RequestIdleCallback;
+  }
+
+  // Polyfill for browsers (Safari) and environments without requestIdleCallback.
+  return (callback) => {
+    const start = Date.now();
+    return setTimeout(() => {
+      callback({
+        didTimeout: false,
+        timeRemaining: () => Math.max(0, DEFAULT_CHUNK_BUDGET_MS - (Date.now() - start)),
+      });
+    }, 1) as unknown as number;
+  };
+}
+
+/**
+ * Builds the source for an inline worker that reconstructs the task from its
+ * string form and posts the result (or error) back to the main thread.
+ */
+function buildWorkerSource(taskSource: string): string {
+  return `
+    const __task = (${taskSource});
+    self.onmessage = async (event) => {
+      try {
+        const result = await __task(...event.data);
+        self.postMessage({ ok: true, result });
+      } catch (err) {
+        self.postMessage({ ok: false, error: (err && err.message) || String(err) });
+      }
+    };
+  `;
+}
+
+function runInWorker<TArgs extends unknown[], TResult>(
+  taskSource: string,
+  args: TArgs,
+  timeoutMs: number,
+): Promise<TResult> {
+  return new Promise<TResult>((resolve, reject) => {
+    let url: string | null = null;
+    let worker: Worker | null = null;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const cleanup = (): void => {
+      if (timer !== null) clearTimeout(timer);
+      if (worker !== null) worker.terminate();
+      if (url !== null) URL.revokeObjectURL(url);
+    };
+
+    try {
+      const blob = new Blob([buildWorkerSource(taskSource)], { type: 'application/javascript' });
+      url = URL.createObjectURL(blob);
+      worker = new Worker(url);
+
+      timer = setTimeout(() => {
+        cleanup();
+        reject(new Error(`useIdleCallbackWorker: task timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      worker.onmessage = (event: MessageEvent) => {
+        cleanup();
+        const data = event.data as { ok: boolean; result?: TResult; error?: string };
+        if (data.ok) {
+          resolve(data.result as TResult);
+        } else {
+          reject(new Error(data.error ?? 'useIdleCallbackWorker: worker task failed'));
+        }
+      };
+
+      worker.onerror = (event: ErrorEvent) => {
+        cleanup();
+        reject(new Error(event.message || 'useIdleCallbackWorker: worker crashed'));
+      };
+
+      worker.postMessage(args);
+    } catch (err) {
+      cleanup();
+      reject(err instanceof Error ? err : new Error(String(err)));
+    }
+  });
+}
+
+function runOnIdle<TArgs extends unknown[], TResult>(
+  task: IdleWorkerTask<TArgs, TResult>,
+  args: TArgs,
+  timeoutMs: number,
+): Promise<TResult> {
+  const requestIdle = getRequestIdleCallback();
+
+  return new Promise<TResult>((resolve, reject) => {
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error(`useIdleCallbackWorker: task timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    requestIdle(
+      () => {
+        if (settled) return;
+
+        Promise.resolve()
+          .then(() => task(...args))
+          .then((value) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            resolve(value);
+          })
+          .catch((err) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            reject(err instanceof Error ? err : new Error(String(err)));
+          });
+      },
+      { timeout: timeoutMs },
+    );
+  });
+}
+
+/**
+ * Offloads a heavy, synchronous task off the critical rendering path to keep
+ * INP and frame timing healthy. Prefers an inline Web Worker (true parallelism)
+ * and transparently falls back to `requestIdleCallback` scheduling when Workers
+ * are unavailable, such as during SSR or in restricted environments.
+ */
+export function useIdleCallbackWorker<TArgs extends unknown[], TResult>(
+  task: IdleWorkerTask<TArgs, TResult>,
+  options: UseIdleCallbackWorkerOptions = {},
+): UseIdleCallbackWorkerReturn<TArgs, TResult> {
+  const { strategy = 'auto', timeoutMs = DEFAULT_TIMEOUT_MS } = options;
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<TResult | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  const taskRef = useRef(task);
+  useEffect(() => {
+    taskRef.current = task;
+  }, [task]);
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const execute = useCallback(
+    async (...args: TArgs): Promise<TResult> => {
+      const currentTask = taskRef.current;
+      if (mountedRef.current) {
+        setLoading(true);
+        setError(null);
+      }
+
+      const canWorker = strategy === 'worker' || (strategy === 'auto' && supportsWorker());
+
+      try {
+        const value = canWorker
+          ? await runInWorker<TArgs, TResult>(currentTask.toString(), args, timeoutMs)
+          : await runOnIdle<TArgs, TResult>(currentTask, args, timeoutMs);
+
+        if (mountedRef.current) {
+          setResult(value);
+          setLoading(false);
+        }
+        return value;
+      } catch (err) {
+        const normalized = err instanceof Error ? err : new Error(String(err));
+        if (mountedRef.current) {
+          setError(normalized);
+          setLoading(false);
+        }
+        throw normalized;
+      }
+    },
+    [strategy, timeoutMs],
+  );
+
+  return { execute, loading, result, error };
+}

--- a/src/hooks/useIdleCallbackWorker/index.ts
+++ b/src/hooks/useIdleCallbackWorker/index.ts
@@ -229,23 +229,26 @@ function runOnIdle<TArgs extends unknown[], TResult>(
       requestIdle(stepGenerator, { timeout: timeoutMs });
     };
 
-    requestIdle((deadline) => {
-      if (settled) return;
+    requestIdle(
+      (deadline) => {
+        if (settled) return;
 
-      try {
-        const outcome = task(...args);
+        try {
+          const outcome = task(...args);
 
-        if (isGenerator<TResult>(outcome)) {
-          iterator = outcome;
-          stepGenerator(deadline);
-          return;
+          if (isGenerator<TResult>(outcome)) {
+            iterator = outcome;
+            stepGenerator(deadline);
+            return;
+          }
+
+          Promise.resolve(outcome).then(finish, fail);
+        } catch (err) {
+          fail(err);
         }
-
-        Promise.resolve(outcome).then(finish, fail);
-      } catch (err) {
-        fail(err);
-      }
-    }, { timeout: timeoutMs });
+      },
+      { timeout: timeoutMs },
+    );
   });
 }
 

--- a/src/hooks/useIdleCallbackWorker/index.ts
+++ b/src/hooks/useIdleCallbackWorker/index.ts
@@ -4,10 +4,17 @@ import { useCallback, useEffect, useRef, useState } from 'react';
  * A pure, serializable task. It must not close over outer scope because it may
  * be stringified and re-instantiated inside a Web Worker where no closure state
  * exists. Receives the same arguments passed to `execute`.
+ *
+ * To get real cooperative chunking on the `requestIdleCallback` fallback path
+ * (no Worker support), author the task as a generator function that yields
+ * periodically between chunks of work and returns the final result. Plain
+ * sync/async tasks still run off the critical path but execute atomically
+ * once idle time is available, since arbitrary synchronous code cannot be
+ * interrupted mid-execution.
  */
 export type IdleWorkerTask<TArgs extends unknown[], TResult> = (
   ...args: TArgs
-) => TResult | Promise<TResult>;
+) => TResult | Promise<TResult> | Generator<unknown, TResult, unknown>;
 
 export type IdleWorkerStrategy = 'auto' | 'worker' | 'idle';
 
@@ -26,7 +33,7 @@ export interface UseIdleCallbackWorkerOptions {
 export interface UseIdleCallbackWorkerReturn<TArgs extends unknown[], TResult> {
   /** Runs the task off the critical path and resolves with its result. */
   execute: (...args: TArgs) => Promise<TResult>;
-  /** Whether a task is currently in flight. */
+  /** Whether at least one task is currently in flight. */
   loading: boolean;
   /** The most recent successful result, or null before the first run. */
   result: TResult | null;
@@ -46,6 +53,9 @@ type RequestIdleCallback = (
 
 const DEFAULT_CHUNK_BUDGET_MS = 8;
 const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** Signals that the Worker itself failed to start (blocked by CSP, parse error, etc.), as opposed to the task throwing inside a running worker. Callers use this to safely retry on the idle fallback without re-running an already-executed task. */
+class WorkerStartError extends Error {}
 
 function supportsWorker(): boolean {
   return (
@@ -74,16 +84,33 @@ function getRequestIdleCallback(): RequestIdleCallback {
   };
 }
 
+function isGenerator<TResult>(value: unknown): value is Generator<unknown, TResult, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Iterator<unknown>).next === 'function' &&
+    typeof (value as Iterable<unknown>)[Symbol.iterator] === 'function'
+  );
+}
+
 /**
  * Builds the source for an inline worker that reconstructs the task from its
- * string form and posts the result (or error) back to the main thread.
+ * string form and posts the result (or error) back to the main thread. Inside
+ * the worker, a generator task is driven to completion synchronously since
+ * there is no main-thread frame budget to protect there.
  */
 function buildWorkerSource(taskSource: string): string {
   return `
     const __task = (${taskSource});
     self.onmessage = async (event) => {
       try {
-        const result = await __task(...event.data);
+        let outcome = __task(...event.data);
+        if (outcome && typeof outcome.next === 'function' && typeof outcome[Symbol.iterator] === 'function') {
+          let step = outcome.next();
+          while (!step.done) step = outcome.next();
+          outcome = step.value;
+        }
+        const result = await outcome;
         self.postMessage({ ok: true, result });
       } catch (err) {
         self.postMessage({ ok: false, error: (err && err.message) || String(err) });
@@ -101,6 +128,7 @@ function runInWorker<TArgs extends unknown[], TResult>(
     let url: string | null = null;
     let worker: Worker | null = null;
     let timer: ReturnType<typeof setTimeout> | null = null;
+    let started = false;
 
     const cleanup = (): void => {
       if (timer !== null) clearTimeout(timer);
@@ -119,6 +147,7 @@ function runInWorker<TArgs extends unknown[], TResult>(
       }, timeoutMs);
 
       worker.onmessage = (event: MessageEvent) => {
+        started = true;
         cleanup();
         const data = event.data as { ok: boolean; result?: TResult; error?: string };
         if (data.ok) {
@@ -130,13 +159,18 @@ function runInWorker<TArgs extends unknown[], TResult>(
 
       worker.onerror = (event: ErrorEvent) => {
         cleanup();
-        reject(new Error(event.message || 'useIdleCallbackWorker: worker crashed'));
+        // An error before any message came back means the worker never
+        // actually ran the task (blocked by CSP, syntax error, etc.), so
+        // callers can safely retry on the idle fallback path.
+        const message = event.message || 'useIdleCallbackWorker: worker crashed';
+        reject(started ? new Error(message) : new WorkerStartError(message));
       };
 
       worker.postMessage(args);
     } catch (err) {
       cleanup();
-      reject(err instanceof Error ? err : new Error(String(err)));
+      const message = err instanceof Error ? err.message : String(err);
+      reject(new WorkerStartError(message));
     }
   });
 }
@@ -150,6 +184,7 @@ function runOnIdle<TArgs extends unknown[], TResult>(
 
   return new Promise<TResult>((resolve, reject) => {
     let settled = false;
+    let iterator: Iterator<unknown, TResult, unknown> | null = null;
 
     const timer = setTimeout(() => {
       if (settled) return;
@@ -157,35 +192,69 @@ function runOnIdle<TArgs extends unknown[], TResult>(
       reject(new Error(`useIdleCallbackWorker: task timed out after ${timeoutMs}ms`));
     }, timeoutMs);
 
-    requestIdle(
-      () => {
-        if (settled) return;
+    const finish = (value: TResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
 
-        Promise.resolve()
-          .then(() => task(...args))
-          .then((value) => {
-            if (settled) return;
-            settled = true;
-            clearTimeout(timer);
-            resolve(value);
-          })
-          .catch((err) => {
-            if (settled) return;
-            settled = true;
-            clearTimeout(timer);
-            reject(err instanceof Error ? err : new Error(String(err)));
-          });
-      },
-      { timeout: timeoutMs },
-    );
+    const fail = (err: unknown): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err instanceof Error ? err : new Error(String(err)));
+    };
+
+    // Drives a generator task across successive idle callbacks, only
+    // advancing while the current idle deadline has time remaining.
+    const stepGenerator = (deadline: IdleDeadline): void => {
+      if (settled || iterator === null) return;
+
+      try {
+        let step = iterator.next();
+        while (!step.done && deadline.timeRemaining() > 0 && !deadline.didTimeout) {
+          step = iterator.next();
+        }
+
+        if (step.done) {
+          finish(step.value);
+          return;
+        }
+      } catch (err) {
+        fail(err);
+        return;
+      }
+
+      requestIdle(stepGenerator, { timeout: timeoutMs });
+    };
+
+    requestIdle((deadline) => {
+      if (settled) return;
+
+      try {
+        const outcome = task(...args);
+
+        if (isGenerator<TResult>(outcome)) {
+          iterator = outcome;
+          stepGenerator(deadline);
+          return;
+        }
+
+        Promise.resolve(outcome).then(finish, fail);
+      } catch (err) {
+        fail(err);
+      }
+    }, { timeout: timeoutMs });
   });
 }
 
 /**
- * Offloads a heavy, synchronous task off the critical rendering path to keep
- * INP and frame timing healthy. Prefers an inline Web Worker (true parallelism)
- * and transparently falls back to `requestIdleCallback` scheduling when Workers
- * are unavailable, such as during SSR or in restricted environments.
+ * Offloads a heavy task off the critical rendering path to keep INP and frame
+ * timing healthy. Prefers an inline Web Worker (true parallelism) and
+ * transparently falls back to `requestIdleCallback` scheduling when Workers
+ * are unavailable or fail to start, such as during SSR or under a
+ * restrictive CSP.
  */
 export function useIdleCallbackWorker<TArgs extends unknown[], TResult>(
   task: IdleWorkerTask<TArgs, TResult>,
@@ -209,9 +278,14 @@ export function useIdleCallbackWorker<TArgs extends unknown[], TResult>(
     };
   }, []);
 
+  // Tracks concurrently in-flight executions so overlapping calls to
+  // `execute` don't clear `loading` while a sibling call is still running.
+  const activeCountRef = useRef(0);
+
   const execute = useCallback(
     async (...args: TArgs): Promise<TResult> => {
       const currentTask = taskRef.current;
+      activeCountRef.current += 1;
       if (mountedRef.current) {
         setLoading(true);
         setError(null);
@@ -221,21 +295,31 @@ export function useIdleCallbackWorker<TArgs extends unknown[], TResult>(
 
       try {
         const value = canWorker
-          ? await runInWorker<TArgs, TResult>(currentTask.toString(), args, timeoutMs)
+          ? await runInWorker<TArgs, TResult>(currentTask.toString(), args, timeoutMs).catch(
+              (err: unknown) => {
+                if (err instanceof WorkerStartError) {
+                  return runOnIdle<TArgs, TResult>(currentTask, args, timeoutMs);
+                }
+                throw err;
+              },
+            )
           : await runOnIdle<TArgs, TResult>(currentTask, args, timeoutMs);
 
         if (mountedRef.current) {
           setResult(value);
-          setLoading(false);
         }
         return value;
       } catch (err) {
         const normalized = err instanceof Error ? err : new Error(String(err));
         if (mountedRef.current) {
           setError(normalized);
-          setLoading(false);
         }
         throw normalized;
+      } finally {
+        activeCountRef.current -= 1;
+        if (mountedRef.current && activeCountRef.current === 0) {
+          setLoading(false);
+        }
       }
     },
     [strategy, timeoutMs],

--- a/src/hooks/useIdleCallbackWorker/useIdleCallbackWorker.test.tsx
+++ b/src/hooks/useIdleCallbackWorker/useIdleCallbackWorker.test.tsx
@@ -88,9 +88,7 @@ describe('useIdleCallbackWorker', () => {
 
   it('does not crash during SSR (no window)', () => {
     const task = (n: number): number => n;
-    expect(() =>
-      renderToString(<SsrProbe task={task} />),
-    ).not.toThrow();
+    expect(() => renderToString(<SsrProbe task={task} />)).not.toThrow();
   });
 
   it('drives a generator task across multiple idle callbacks', async () => {

--- a/src/hooks/useIdleCallbackWorker/useIdleCallbackWorker.test.tsx
+++ b/src/hooks/useIdleCallbackWorker/useIdleCallbackWorker.test.tsx
@@ -1,0 +1,100 @@
+import { act, renderHook } from '@testing-library/react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useIdleCallbackWorker } from './index';
+
+// jsdom has no real Worker, so tests exercise the requestIdleCallback path by
+// forcing the `idle` strategy, plus SSR safety and error handling.
+
+describe('useIdleCallbackWorker', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'requestIdleCallback',
+      (cb: (deadline: { didTimeout: boolean; timeRemaining: () => number }) => void): number => {
+        cb({ didTimeout: false, timeRemaining: () => 50 });
+        return 1;
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('resolves with the task result on the idle path', async () => {
+    const task = (items: number[]): number => items.reduce((sum, n) => sum + n, 0);
+    const { result } = renderHook(() => useIdleCallbackWorker(task, { strategy: 'idle' }));
+
+    let value: number | undefined;
+    await act(async () => {
+      value = await result.current.execute([1, 2, 3, 4]);
+    });
+
+    expect(value).toBe(10);
+    expect(result.current.result).toBe(10);
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('supports async tasks', async () => {
+    const task = async (n: number): Promise<number> => n * 2;
+    const { result } = renderHook(() => useIdleCallbackWorker(task, { strategy: 'idle' }));
+
+    let value: number | undefined;
+    await act(async () => {
+      value = await result.current.execute(21);
+    });
+
+    expect(value).toBe(42);
+  });
+
+  it('captures errors thrown inside the task', async () => {
+    const task = (): number => {
+      throw new Error('boom');
+    };
+    const { result } = renderHook(() => useIdleCallbackWorker(task, { strategy: 'idle' }));
+
+    await act(async () => {
+      await expect(result.current.execute()).rejects.toThrow('boom');
+    });
+
+    expect(result.current.error?.message).toBe('boom');
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('rejects when the idle task exceeds the timeout', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('requestIdleCallback', (): number => 1); // never invokes the callback
+
+    const task = (): number => 1;
+    const { result } = renderHook(() =>
+      useIdleCallbackWorker(task, { strategy: 'idle', timeoutMs: 100 }),
+    );
+
+    let rejection: Promise<unknown>;
+    act(() => {
+      rejection = result.current.execute();
+      rejection.catch(() => undefined);
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(101);
+    });
+
+    await expect(rejection!).rejects.toThrow(/timed out/);
+    vi.useRealTimers();
+  });
+
+  it('does not crash during SSR (no window)', () => {
+    const task = (n: number): number => n;
+    expect(() =>
+      renderToString(<SsrProbe task={task} />),
+    ).not.toThrow();
+  });
+});
+
+function SsrProbe({ task }: { task: (n: number) => number }): null {
+  useIdleCallbackWorker(task);
+  return null;
+}

--- a/src/hooks/useIdleCallbackWorker/useIdleCallbackWorker.test.tsx
+++ b/src/hooks/useIdleCallbackWorker/useIdleCallbackWorker.test.tsx
@@ -92,6 +92,98 @@ describe('useIdleCallbackWorker', () => {
       renderToString(<SsrProbe task={task} />),
     ).not.toThrow();
   });
+
+  it('drives a generator task across multiple idle callbacks', async () => {
+    let idleCalls = 0;
+    vi.stubGlobal(
+      'requestIdleCallback',
+      (cb: (deadline: { didTimeout: boolean; timeRemaining: () => number }) => void): number => {
+        idleCalls += 1;
+        // Time remaining is only positive for the first read, so each idle
+        // callback advances exactly one generator step.
+        let reads = 0;
+        cb({ didTimeout: false, timeRemaining: () => (reads++ === 0 ? 1 : 0) });
+        return idleCalls;
+      },
+    );
+
+    function* task(items: number[]): Generator<void, number, void> {
+      let sum = 0;
+      for (const item of items) {
+        sum += item;
+        yield;
+      }
+      return sum;
+    }
+
+    const { result } = renderHook(() => useIdleCallbackWorker(task, { strategy: 'idle' }));
+
+    let value: number | undefined;
+    await act(async () => {
+      value = await result.current.execute([1, 2, 3, 4]);
+    });
+
+    expect(value).toBe(10);
+    expect(idleCalls).toBeGreaterThan(1);
+  });
+
+  it('falls back to the idle path when the worker fails to start', async () => {
+    class FailingWorker {
+      constructor() {
+        throw new Error('CSP blocked worker');
+      }
+    }
+    vi.stubGlobal('Worker', FailingWorker);
+    vi.stubGlobal('Blob', class {} as unknown as typeof Blob);
+    vi.stubGlobal('URL', {
+      createObjectURL: () => 'blob:mock',
+      revokeObjectURL: () => undefined,
+    });
+
+    const task = (n: number): number => n * 2;
+    const { result } = renderHook(() => useIdleCallbackWorker(task, { strategy: 'worker' }));
+
+    let value: number | undefined;
+    await act(async () => {
+      value = await result.current.execute(21);
+    });
+
+    expect(value).toBe(42);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('keeps loading true until all overlapping executions settle', async () => {
+    let resolveFirst!: () => void;
+    const first = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    const task = async (id: number): Promise<number> => {
+      if (id === 1) await first;
+      return id;
+    };
+    const { result } = renderHook(() => useIdleCallbackWorker(task, { strategy: 'idle' }));
+
+    let firstDone: Promise<number>;
+    let secondDone: Promise<number>;
+    act(() => {
+      firstDone = result.current.execute(1);
+      secondDone = result.current.execute(2);
+    });
+
+    await act(async () => {
+      await secondDone;
+    });
+
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      resolveFirst();
+      await firstDone;
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
 });
 
 function SsrProbe({ task }: { task: (n: number) => number }): null {

--- a/src/hooks/useNetworkEfficiency/index.ts
+++ b/src/hooks/useNetworkEfficiency/index.ts
@@ -1,9 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 export type NetworkResourceFilter =
-  | string
-  | RegExp
-  | ((entry: PerformanceResourceTiming) => boolean);
+  string | RegExp | ((entry: PerformanceResourceTiming) => boolean);
 
 export type NetworkEffectiveType = 'slow-2g' | '2g' | '3g' | '4g' | string;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,3 +81,11 @@ export type {
   IntersectionObserverMetrics,
   UseIntersectionObserverReturn,
 } from './hooks/useIntersectionObserver';
+
+export { useIdleCallbackWorker } from './hooks/useIdleCallbackWorker';
+export type {
+  IdleWorkerStrategy,
+  IdleWorkerTask,
+  UseIdleCallbackWorkerOptions,
+  UseIdleCallbackWorkerReturn,
+} from './hooks/useIdleCallbackWorker';


### PR DESCRIPTION
## Description

Synchronous operations like processing 10,000+ array items, filtering, or heavy math blocks freeze the UI thread and destroy INP. We should introduce `useIdleCallbackWorker` which splits execution into non-blocking chunks using `requestIdleCallback` or effortlessly offloads it into a lightweight inline Web Worker.

## Proposed API
```typescript
const { execute, loading, result } = useIdleCallbackWorker(heavyFilterFunction);

// Usage inside component
const handleSearch = async () => {
  const filtered = await execute(largeDataset, searchCriteria);
};
```

Implementation Details
1. Fallback pattern: If the browser supports Web Workers, dynamically instantiate an inline Worker via a dynamic Blob URL created from the passed function string.
2. If Workers aren't ideal/supported, fall back to slicing the dataset processing over chunks using cooperative scheduling via requestIdleCallback.
3. Provide a standard Promise-based or reactive hook architecture.
Acceptance Criteria
- [ ] Offloads execution without causing visible frame drops on the main UI thread.
- [ ] Handled safely across environments (SSR compatibility check since Worker and Blob don't exist on the server).
- [ ] Includes error handling boundaries for broken worker execution trees.