### PR TITLE
Feat: Add useRenderCount hook for lightweight render counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ npm install web-vitals
 | `useIntersectionObserver` | Lazy-loading visibility state plus first-visible and total-visible metrics | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-intersection-observer) |
 | `useIdleCallbackWorker` | Offload heavy tasks to an inline Web Worker with `requestIdleCallback` fallback | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-idle-callback-worker) |
 | `useWhyDidYouUpdate` | Diagnose wasted renders by diffing props and flagging reference-only changes | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-why-did-you-update) |
+| `useRenderCount` | Lightweight render counter with optional console logging and a warning threshold | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-render-count) |
 
 See the [docs overview](https://valyefimov.github.io/react-perf-hooks/docs/getting-started) for a complete reference.
 

--- a/docs/hooks/use-render-count.mdx
+++ b/docs/hooks/use-render-count.mdx
@@ -15,18 +15,18 @@ function useRenderCount(name: string, options?: UseRenderCountOptions): number;
 
 ## Parameters
 
-| Name      | Type                   | Required | Description                                |
-| --------- | ---------------------- | -------- | ------------------------------------------- |
+| Name      | Type                    | Required | Description                                 |
+| --------- | ----------------------- | -------- | ------------------------------------------- |
 | `name`    | `string`                | Yes      | Display name used in log/warning messages.  |
 | `options` | `UseRenderCountOptions` | No       | Logging and threshold controls (see below). |
 
 ### Options
 
-| Name                | Type      | Default                                      | Description                                                              |
-| ------------------- | --------- | --------------------------------------------- | -------------------------------------------------------------------------- |
-| `enabled`           | `boolean` | `true` in development, `false` in production | Force enable/disable. Disabled runs are a safe noop that returns `0`.    |
-| `logOnRender`       | `boolean` | `false`                                       | Log the running count via `console.log` on every render.                 |
-| `thresholdWarning`  | `number`  | `undefined`                                   | Fires a single `console.warn` the render the count reaches this value.   |
+| Name               | Type      | Default                                      | Description                                                            |
+| ------------------ | --------- | -------------------------------------------- | ---------------------------------------------------------------------- |
+| `enabled`          | `boolean` | `true` in development, `false` in production | Force enable/disable. Disabled runs are a safe noop that returns `0`.  |
+| `logOnRender`      | `boolean` | `false`                                      | Log the running count via `console.log` on every render.               |
+| `thresholdWarning` | `number`  | `undefined`                                  | Fires a single `console.warn` the render the count reaches this value. |
 
 ## Return value
 

--- a/docs/hooks/use-render-count.mdx
+++ b/docs/hooks/use-render-count.mdx
@@ -1,0 +1,57 @@
+---
+title: useRenderCount
+description: Lightweight, zero-dependency render counter with optional console logging and a warning threshold.
+---
+
+## Description and use case
+
+`useRenderCount` is the simplest possible render-thrashing indicator: a ref counter incremented synchronously in the render body, returned as a plain number you can drop straight into a debug badge. Reach for it when you just need a quick "how many times did this render" signal, without the overhead of diffing props like `useWhyDidYouUpdate`.
+
+## API signature
+
+```ts
+function useRenderCount(name: string, options?: UseRenderCountOptions): number;
+```
+
+## Parameters
+
+| Name      | Type                   | Required | Description                                |
+| --------- | ---------------------- | -------- | ------------------------------------------- |
+| `name`    | `string`                | Yes      | Display name used in log/warning messages.  |
+| `options` | `UseRenderCountOptions` | No       | Logging and threshold controls (see below). |
+
+### Options
+
+| Name                | Type      | Default                                      | Description                                                              |
+| ------------------- | --------- | --------------------------------------------- | -------------------------------------------------------------------------- |
+| `enabled`           | `boolean` | `true` in development, `false` in production | Force enable/disable. Disabled runs are a safe noop that returns `0`.    |
+| `logOnRender`       | `boolean` | `false`                                       | Log the running count via `console.log` on every render.                 |
+| `thresholdWarning`  | `number`  | `undefined`                                   | Fires a single `console.warn` the render the count reaches this value.   |
+
+## Return value
+
+The current render count as a plain `number`, starting at `1` on the first render.
+
+## Strict Mode behavior
+
+React Strict Mode (development only) invokes component render bodies twice per commit to surface side-effect bugs. Because `useRenderCount` increments its counter directly in the render body (not in a `useEffect`), each Strict Mode commit bumps the count twice, so the number will run roughly 2x higher than in production. This is a deliberate tradeoff: counting in an effect would under-count by skipping the render phase itself, which defeats the purpose of a render counter.
+
+## Code example
+
+```tsx
+import { useRenderCount } from 'react-perf-hooks';
+
+function DashboardCard() {
+  const renderCount = useRenderCount('DashboardCard', {
+    logOnRender: true,
+    thresholdWarning: 10,
+  });
+
+  return <span className="debug-badge">Rendered {renderCount} times</span>;
+}
+```
+
+## Companion article
+
+- [dev.to companion article](https://dev.to/search?q=useRenderCount)
+- [Medium companion article](https://medium.com/search?q=useRenderCount)

--- a/src/hooks/useRenderCount/index.ts
+++ b/src/hooks/useRenderCount/index.ts
@@ -1,0 +1,75 @@
+import { useId } from 'react';
+
+export interface UseRenderCountOptions {
+  /**
+   * Enable tracking. Defaults to true in development, false in production.
+   * Pass `true` to force-enable in production (e.g. for debugging deploys).
+   */
+  enabled?: boolean;
+  /** Log the running count to the console on every render. Default: false */
+  logOnRender?: boolean;
+  /**
+   * When the count reaches this value, a single `console.warn` fires flagging
+   * the component as a possible thrashing hotspot. Omit to disable.
+   */
+  thresholdWarning?: number;
+}
+
+// Keyed by the per-instance id from useId rather than a ref, since reading
+// (or writing) a ref's `current` during render is unsafe: React may discard
+// or replay the render (e.g. Strict Mode, Suspense) without the ref mutation
+// itself being replayed consistently, and the eslint-plugin-react-hooks
+// "refs" rule flags exactly this. A module-level map keyed by a stable id is
+// safe to read and write directly in the render body.
+const renderCounts = new Map<string, number>();
+
+/**
+ * Tracks how many times a component has rendered, incremented synchronously
+ * in the render body so the returned value is always current for the render
+ * it's read in (no `useEffect` lag).
+ *
+ * Note on React Strict Mode: in development, Strict Mode invokes component
+ * render bodies twice per commit to surface side-effect bugs. Since the
+ * counter increments directly in the render body, each Strict Mode commit
+ * bumps it twice, inflating the count relative to production. This is a
+ * known, documented tradeoff of counting during render rather than in an
+ * effect (which would under-count by skipping the render phase entirely).
+ *
+ * @example
+ * function DashboardCard() {
+ *   const renderCount = useRenderCount('DashboardCard', {
+ *     logOnRender: true,
+ *     thresholdWarning: 10,
+ *   });
+ *
+ *   return <span>Rendered {renderCount} times</span>;
+ * }
+ */
+export function useRenderCount(name: string, options: UseRenderCountOptions = {}): number {
+  const {
+    enabled = process.env.NODE_ENV !== 'production',
+    logOnRender = false,
+    thresholdWarning,
+  } = options;
+
+  const instanceId = useId();
+
+  if (!enabled) {
+    return renderCounts.get(instanceId) ?? 0;
+  }
+
+  const count = (renderCounts.get(instanceId) ?? 0) + 1;
+  renderCounts.set(instanceId, count);
+
+  if (logOnRender) {
+    console.log(`[useRenderCount] "${name}" rendered ${count} time${count === 1 ? '' : 's'}`);
+  }
+
+  if (thresholdWarning !== undefined && count === thresholdWarning) {
+    console.warn(
+      `[useRenderCount] "${name}" has rendered ${count} times, reaching the warning threshold of ${thresholdWarning}.`,
+    );
+  }
+
+  return count;
+}

--- a/src/hooks/useRenderCount/index.ts
+++ b/src/hooks/useRenderCount/index.ts
@@ -1,4 +1,4 @@
-import { useId } from 'react';
+import { useState } from 'react';
 
 export interface UseRenderCountOptions {
   /**
@@ -15,13 +15,13 @@ export interface UseRenderCountOptions {
   thresholdWarning?: number;
 }
 
-// Keyed by the per-instance id from useId rather than a ref, since reading
-// (or writing) a ref's `current` during render is unsafe: React may discard
-// or replay the render (e.g. Strict Mode, Suspense) without the ref mutation
-// itself being replayed consistently, and the eslint-plugin-react-hooks
-// "refs" rule flags exactly this. A module-level map keyed by a stable id is
-// safe to read and write directly in the render body.
-const renderCounts = new Map<string, number>();
+// Keyed by a per-instance identity object rather than a ref (reading/writing
+// a ref's `current` during render is unsafe and flagged by the
+// eslint-plugin-react-hooks "refs" rule) or `useId` (deterministic across SSR
+// requests, so concurrent requests would collide and leak counts into each
+// other's HTML). A WeakMap keyed on a unique object is GC'd automatically on
+// unmount, unlike a Map keyed by a string id, which would grow forever.
+const renderCounts = new WeakMap<object, number>();
 
 /**
  * Tracks how many times a component has rendered, incremented synchronously
@@ -52,14 +52,14 @@ export function useRenderCount(name: string, options: UseRenderCountOptions = {}
     thresholdWarning,
   } = options;
 
-  const instanceId = useId();
+  const [instanceKey] = useState<object>(() => ({}));
 
   if (!enabled) {
-    return renderCounts.get(instanceId) ?? 0;
+    return renderCounts.get(instanceKey) ?? 0;
   }
 
-  const count = (renderCounts.get(instanceId) ?? 0) + 1;
-  renderCounts.set(instanceId, count);
+  const count = (renderCounts.get(instanceKey) ?? 0) + 1;
+  renderCounts.set(instanceKey, count);
 
   if (logOnRender) {
     console.log(`[useRenderCount] "${name}" rendered ${count} time${count === 1 ? '' : 's'}`);

--- a/src/hooks/useRenderCount/useRenderCount.test.tsx
+++ b/src/hooks/useRenderCount/useRenderCount.test.tsx
@@ -1,0 +1,73 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useRenderCount } from './index';
+
+describe('useRenderCount', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns 1 on the first render', () => {
+    const { result } = renderHook(() => useRenderCount('Test'));
+    expect(result.current).toBe(1);
+  });
+
+  it('increments the count on every render', () => {
+    const { result, rerender } = renderHook(() => useRenderCount('Test'));
+
+    rerender();
+    rerender();
+    rerender();
+
+    expect(result.current).toBe(4);
+  });
+
+  it('does not log by default', () => {
+    const { rerender } = renderHook(() => useRenderCount('Test'));
+    rerender();
+
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('logs the running count on every render when logOnRender is true', () => {
+    const { rerender } = renderHook(() => useRenderCount('Test', { logOnRender: true }));
+    rerender();
+
+    expect(console.log).toHaveBeenCalledTimes(2);
+    expect(console.log).toHaveBeenLastCalledWith('[useRenderCount] "Test" rendered 2 times');
+  });
+
+  it('warns exactly once when the render count reaches thresholdWarning', () => {
+    const { rerender } = renderHook(() => useRenderCount('Test', { thresholdWarning: 2 }));
+
+    expect(console.warn).not.toHaveBeenCalled();
+
+    rerender();
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      '[useRenderCount] "Test" has rendered 2 times, reaching the warning threshold of 2.',
+    );
+
+    rerender();
+    rerender();
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a frozen count and skips logging/warning when disabled', () => {
+    const { result, rerender } = renderHook(() =>
+      useRenderCount('Test', { enabled: false, logOnRender: true, thresholdWarning: 1 }),
+    );
+
+    rerender();
+    rerender();
+
+    expect(result.current).toBe(0);
+    expect(console.log).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,3 +92,6 @@ export type {
 
 export { useWhyDidYouUpdate } from './hooks/useWhyDidYouUpdate';
 export type { UseWhyDidYouUpdateOptions, WhyDidYouUpdateChange } from './hooks/useWhyDidYouUpdate';
+
+export { useRenderCount } from './hooks/useRenderCount';
+export type { UseRenderCountOptions } from './hooks/useRenderCount';


### PR DESCRIPTION
## Summary
- New zero-dependency `useRenderCount` hook: returns raw render count, optional `logOnRender` console logging, optional `thresholdWarning` (fires a single `console.warn` when reached)
- Documents React Strict Mode double-invoke behavior instead of trying to suppress it (render-body counting can't safely dedupe Strict Mode's replayed render)
- README + docs page added

Closes #34

## Test plan
- [x] `pnpm test:run` (new suite: 6/6 passing)
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm build`