### PR TITLE
Feat: Add PerfProvider and centralized analytics reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ npm install web-vitals
 | `useIntersectionObserver` | Lazy-loading visibility state plus first-visible and total-visible metrics | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-intersection-observer) |
 | `useIdleCallbackWorker` | Offload heavy tasks to an inline Web Worker with `requestIdleCallback` fallback | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-idle-callback-worker) |
 | `useWhyDidYouUpdate` | Diagnose wasted renders by diffing props and flagging reference-only changes | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/hooks/use-why-did-you-update) |
+| `PerfProvider` | Centralized React Context that collects metrics from `useINP`, `useCLS`, and `useLongTasks` for one analytics callback | [Full docs](https://valyefimov.github.io/react-perf-hooks/docs/guides/perf-provider) |
 
 See the [docs overview](https://valyefimov.github.io/react-perf-hooks/docs/getting-started) for a complete reference.
 

--- a/docs/guides/perf-provider.mdx
+++ b/docs/guides/perf-provider.mdx
@@ -84,8 +84,10 @@ import { datadogRum } from '@datadog/browser-rum';
 ```tsx
 <PerfProvider
   onMetricsReport={(metricName, value) => {
+    // Note: CLS is a small unitless score (e.g. 0.12) - don't round it, or you'll
+    // lose nearly all precision. Round only duration-based metrics like INP.
     window.gtag?.('event', metricName, {
-      value: Math.round(value),
+      value: metricName === 'CLS' ? value : Math.round(value),
       event_category: 'Web Vitals',
     });
   }}

--- a/docs/guides/perf-provider.mdx
+++ b/docs/guides/perf-provider.mdx
@@ -1,0 +1,100 @@
+---
+title: PerfProvider
+description: Centralize analytics reporting for react-perf-hooks metrics.
+---
+
+## Description and use case
+
+`PerfProvider` is a lightweight React Context that acts as a collector hub for the metrics emitted by hooks like [`useINP`](/docs/hooks/use-inp), [`useCLS`](/docs/hooks/use-cls), and [`useLongTasks`](/docs/hooks/use-long-tasks). Instead of wiring an `onMetric`/`onLongTask` callback to every hook instance, wrap your app once and every hook rendered underneath automatically bubbles its metrics to a single `onMetricsReport` handler.
+
+When no `PerfProvider` is present, hooks fall back to local-only execution, so adding it is fully opt-in and never a breaking change.
+
+## API signature
+
+```ts
+function PerfProvider(props: PerfProviderProps): JSX.Element;
+function usePerfContext(): PerfContextValue | null;
+```
+
+## Parameters
+
+| Name                       | Type                                                                | Required | Description                                                          |
+| --------------------------- | -------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------- |
+| `onMetricsReport`           | `(metricName: string, value: number, attribution?: unknown) => void` | Yes      | Called whenever a metric bubbles up from a hook rendered as a descendant. |
+| `children`                  | `ReactNode`                                                         | No       | Application tree to instrument.                                      |
+
+## Code example
+
+```tsx
+import { PerfProvider, useINP, useLongTasks } from 'react-perf-hooks';
+
+function App() {
+  return (
+    <PerfProvider
+      onMetricsReport={(metricName, value, attribution) => {
+        navigator.sendBeacon('/analytics', JSON.stringify({ metricName, value, attribution }));
+      }}
+    >
+      <MyApplication />
+    </PerfProvider>
+  );
+}
+
+function MyApplication() {
+  // Metrics from these hooks bubble to PerfProvider's onMetricsReport automatically.
+  useINP();
+  useLongTasks({ screen: () => location.pathname });
+
+  return null;
+}
+```
+
+## Integrating with popular aggregators
+
+### Sentry
+
+```tsx
+import * as Sentry from '@sentry/react';
+
+<PerfProvider
+  onMetricsReport={(metricName, value) => {
+    Sentry.setMeasurement(metricName, value, 'millisecond');
+  }}
+>
+  <MyApplication />
+</PerfProvider>;
+```
+
+### Datadog RUM
+
+```tsx
+import { datadogRum } from '@datadog/browser-rum';
+
+<PerfProvider
+  onMetricsReport={(metricName, value, attribution) => {
+    datadogRum.addAction(metricName, { value, attribution });
+  }}
+>
+  <MyApplication />
+</PerfProvider>;
+```
+
+### Google Analytics 4
+
+```tsx
+<PerfProvider
+  onMetricsReport={(metricName, value) => {
+    window.gtag?.('event', metricName, {
+      value: Math.round(value),
+      event_category: 'Web Vitals',
+    });
+  }}
+>
+  <MyApplication />
+</PerfProvider>;
+```
+
+## Companion article
+
+- [dev.to companion article](https://dev.to/search?q=PerfProvider)
+- [Medium companion article](https://medium.com/search?q=PerfProvider)

--- a/docs/guides/perf-provider.mdx
+++ b/docs/guides/perf-provider.mdx
@@ -18,10 +18,10 @@ function usePerfContext(): PerfContextValue | null;
 
 ## Parameters
 
-| Name                       | Type                                                                | Required | Description                                                          |
-| --------------------------- | -------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------- |
-| `onMetricsReport`           | `(metricName: string, value: number, attribution?: unknown) => void` | Yes      | Called whenever a metric bubbles up from a hook rendered as a descendant. |
-| `children`                  | `ReactNode`                                                         | No       | Application tree to instrument.                                      |
+| Name              | Type                                                                 | Required | Description                                                               |
+| ----------------- | -------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------- |
+| `onMetricsReport` | `(metricName: string, value: number, attribution?: unknown) => void` | Yes      | Called whenever a metric bubbles up from a hook rendered as a descendant. |
+| `children`        | `ReactNode`                                                          | No       | Application tree to instrument.                                           |
 
 ## Code example
 
@@ -91,7 +91,7 @@ import { datadogRum } from '@datadog/browser-rum';
   }}
 >
   <MyApplication />
-</PerfProvider>;
+</PerfProvider>
 ```
 
 ## Companion article

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -31,7 +31,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Guides',
-      items: ['guides/performance-checklist'],
+      items: ['guides/performance-checklist', 'guides/perf-provider'],
     },
   ],
 };

--- a/src/components/PerfProvider/PerfProvider.test.tsx
+++ b/src/components/PerfProvider/PerfProvider.test.tsx
@@ -1,0 +1,63 @@
+import { render, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PerfProvider, usePerfContext, type PerfContextValue } from './index';
+
+describe('PerfProvider', () => {
+  it('returns null from usePerfContext when no provider is present', () => {
+    const { result } = renderHook(() => usePerfContext());
+
+    expect(result.current).toBeNull();
+  });
+
+  it('exposes reportMetric that forwards to onMetricsReport', () => {
+    const onMetricsReport = vi.fn();
+
+    const { result } = renderHook(() => usePerfContext(), {
+      wrapper: ({ children }) => (
+        <PerfProvider onMetricsReport={onMetricsReport}>{children}</PerfProvider>
+      ),
+    });
+
+    result.current?.reportMetric('INP', 250, { rating: 'poor' });
+
+    expect(onMetricsReport).toHaveBeenCalledWith('INP', 250, { rating: 'poor' });
+  });
+
+  it('always calls the latest onMetricsReport handler', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    let capturedContext: PerfContextValue | null = null;
+
+    function Capture() {
+      capturedContext = usePerfContext();
+      return null;
+    }
+
+    const { rerender } = render(
+      <PerfProvider onMetricsReport={first}>
+        <Capture />
+      </PerfProvider>,
+    );
+
+    rerender(
+      <PerfProvider onMetricsReport={second}>
+        <Capture />
+      </PerfProvider>,
+    );
+
+    capturedContext?.reportMetric('CLS', 0.05);
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith('CLS', 0.05, undefined);
+  });
+
+  it('renders children', () => {
+    const { getByText } = render(
+      <PerfProvider onMetricsReport={vi.fn()}>
+        <span>child</span>
+      </PerfProvider>,
+    );
+
+    expect(getByText('child')).toBeInTheDocument();
+  });
+});

--- a/src/components/PerfProvider/index.tsx
+++ b/src/components/PerfProvider/index.tsx
@@ -1,0 +1,67 @@
+import { createContext, useContext, useEffect, useMemo, useRef, type ReactNode } from 'react';
+
+export type PerfMetricAttribution = unknown;
+
+export type PerfMetricsReporter = (
+  metricName: string,
+  value: number,
+  attribution?: PerfMetricAttribution,
+) => void;
+
+export interface PerfContextValue {
+  /** Reports a metric to the nearest `PerfProvider`. */
+  reportMetric: PerfMetricsReporter;
+}
+
+const PerfContext = createContext<PerfContextValue | null>(null);
+
+export interface PerfProviderProps {
+  /**
+   * Called whenever a metric bubbles up from a hook rendered under this provider.
+   * Use this to forward metrics to an analytics aggregator (Sentry, Datadog, GA4, ...).
+   */
+  onMetricsReport: PerfMetricsReporter;
+  children?: ReactNode;
+}
+
+/**
+ * Centralized collector for performance metrics emitted by hooks like `useINP`,
+ * `useCLS`, and `useLongTasks`. Hooks rendered under a `PerfProvider` automatically
+ * bubble their metrics to `onMetricsReport` in addition to their own local callbacks.
+ * When no `PerfProvider` is present, hooks fall back to local-only execution.
+ *
+ * @example
+ * function App() {
+ *   return (
+ *     <PerfProvider
+ *       onMetricsReport={(metricName, value, attribution) => {
+ *         navigator.sendBeacon('/analytics', JSON.stringify({ metricName, value, attribution }));
+ *       }}
+ *     >
+ *       <MyApplication />
+ *     </PerfProvider>
+ *   );
+ * }
+ */
+export function PerfProvider({ onMetricsReport, children }: PerfProviderProps) {
+  const onMetricsReportRef = useRef(onMetricsReport);
+
+  useEffect(() => {
+    onMetricsReportRef.current = onMetricsReport;
+  }, [onMetricsReport]);
+
+  const value = useMemo<PerfContextValue>(
+    () => ({
+      reportMetric: (metricName, metricValue, attribution) =>
+        onMetricsReportRef.current(metricName, metricValue, attribution),
+    }),
+    [],
+  );
+
+  return <PerfContext.Provider value={value}>{children}</PerfContext.Provider>;
+}
+
+/** Reads the nearest `PerfProvider` context, or `null` when none is present. */
+export function usePerfContext(): PerfContextValue | null {
+  return useContext(PerfContext);
+}

--- a/src/components/PerfProvider/index.tsx
+++ b/src/components/PerfProvider/index.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
 
 export type PerfMetricAttribution = unknown;
 
@@ -44,18 +44,12 @@ export interface PerfProviderProps {
  * }
  */
 export function PerfProvider({ onMetricsReport, children }: PerfProviderProps) {
-  const onMetricsReportRef = useRef(onMetricsReport);
-
-  useEffect(() => {
-    onMetricsReportRef.current = onMetricsReport;
-  }, [onMetricsReport]);
-
   const value = useMemo<PerfContextValue>(
     () => ({
       reportMetric: (metricName, metricValue, attribution) =>
-        onMetricsReportRef.current(metricName, metricValue, attribution),
+        onMetricsReport(metricName, metricValue, attribution),
     }),
-    [],
+    [onMetricsReport],
   );
 
   return <PerfContext.Provider value={value}>{children}</PerfContext.Provider>;

--- a/src/hooks/useCLS/index.ts
+++ b/src/hooks/useCLS/index.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { usePerfContext } from '../../components/PerfProvider';
 
 export type CLSRating = 'good' | 'needs-improvement' | 'poor';
 
@@ -229,6 +230,7 @@ export function useCLS<T extends Element = HTMLElement>(
   const ignoreRecentInputRef = useRef(ignoreRecentInput);
   const maxEntriesRef = useRef(maxEntries);
   const isSupported = supportsLayoutShift();
+  const perfContext = usePerfContext();
 
   useEffect(() => {
     onMetricRef.current = onMetric;
@@ -293,9 +295,10 @@ export function useCLS<T extends Element = HTMLElement>(
       setEntries((previous) => [...previous, nextMetric].slice(-maxEntriesRef.current));
       if (currentValueRef.current > previousValue) {
         onMetricRef.current?.(nextMetric);
+        perfContext?.reportMetric(nextMetric.name, nextMetric.value, nextMetric);
       }
     },
-    [],
+    [perfContext],
   );
 
   useEffect(() => {

--- a/src/hooks/useCLS/useCLS.test.tsx
+++ b/src/hooks/useCLS/useCLS.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PerfProvider } from '../../components/PerfProvider';
 import { useCLS } from './index';
 
 type ObserverCallback = (
@@ -371,6 +372,30 @@ describe('useCLS', () => {
 
     expect(result.current.isSupported).toBe(false);
     expect(MockPerformanceObserver.observe).not.toHaveBeenCalled();
+  });
+
+  it('reports metrics to a wrapping PerfProvider', () => {
+    const target = document.createElement('div');
+    const onMetricsReport = vi.fn();
+    const { result } = renderHook(() => useCLS<HTMLDivElement>(), {
+      wrapper: ({ children }) => (
+        <PerfProvider onMetricsReport={onMetricsReport}>{children}</PerfProvider>
+      ),
+    });
+    attachRef(result.current.ref, target);
+
+    emitEntry({
+      value: 0.12,
+      startTime: 1,
+      hadRecentInput: false,
+      sources: [{ node: target }],
+    });
+
+    expect(onMetricsReport).toHaveBeenCalledWith(
+      'CLS',
+      0.12,
+      expect.objectContaining({ name: 'CLS', value: 0.12 }),
+    );
   });
 
   it('disconnects the observer on unmount', () => {

--- a/src/hooks/useINP/index.ts
+++ b/src/hooks/useINP/index.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { usePerfContext } from '../../components/PerfProvider';
 
 export type INPRating = 'good' | 'needs-improvement' | 'poor';
 
@@ -126,19 +127,24 @@ export function useINP(options: UseINPOptions = {}): UseINPReturn {
   const worstValueRef = useRef(0);
   const onMetricRef = useRef(onMetric);
   const isSupported = supportsEventTiming();
+  const perfContext = usePerfContext();
 
   useEffect(() => {
     onMetricRef.current = onMetric;
   }, [onMetric]);
 
-  const updateMetric = useCallback((entry: PerformanceEventTimingLike) => {
-    if (entry.duration <= worstValueRef.current) return;
+  const updateMetric = useCallback(
+    (entry: PerformanceEventTimingLike) => {
+      if (entry.duration <= worstValueRef.current) return;
 
-    const nextMetric = toINPMetric(entry);
-    worstValueRef.current = nextMetric.value;
-    setMetric(nextMetric);
-    onMetricRef.current?.(nextMetric);
-  }, []);
+      const nextMetric = toINPMetric(entry);
+      worstValueRef.current = nextMetric.value;
+      setMetric(nextMetric);
+      onMetricRef.current?.(nextMetric);
+      perfContext?.reportMetric(nextMetric.name, nextMetric.value, nextMetric);
+    },
+    [perfContext],
+  );
 
   useEffect(() => {
     if (!enabled || !isSupported) return;

--- a/src/hooks/useINP/useINP.test.tsx
+++ b/src/hooks/useINP/useINP.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PerfProvider } from '../../components/PerfProvider';
 import { useINP } from './index';
 
 type ObserverCallback = (
@@ -171,6 +172,31 @@ describe('useINP', () => {
 
     expect(result.current.isSupported).toBe(false);
     expect(MockPerformanceObserver.observe).not.toHaveBeenCalled();
+  });
+
+  it('reports metrics to a wrapping PerfProvider', () => {
+    const onMetricsReport = vi.fn();
+    renderHook(() => useINP(), {
+      wrapper: ({ children }) => (
+        <PerfProvider onMetricsReport={onMetricsReport}>{children}</PerfProvider>
+      ),
+    });
+
+    emitEntry({ name: 'click', duration: 220, startTime: 10, interactionId: 1 });
+
+    expect(onMetricsReport).toHaveBeenCalledWith(
+      'INP',
+      220,
+      expect.objectContaining({ name: 'INP', value: 220 }),
+    );
+  });
+
+  it('does not report metrics when no PerfProvider is present', () => {
+    const { result } = renderHook(() => useINP());
+
+    emitEntry({ name: 'click', duration: 220, startTime: 10, interactionId: 1 });
+
+    expect(result.current.value).toBe(220);
   });
 
   it('disconnects the observer on unmount', () => {

--- a/src/hooks/useLongTasks/index.ts
+++ b/src/hooks/useLongTasks/index.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { usePerfContext } from '../../components/PerfProvider';
 
 export interface LongTaskAttribution {
   /** Attribution name reported by the browser. */
@@ -224,6 +225,7 @@ export function useLongTasks(options: UseLongTasksOptions = {}): UseLongTasksRet
   const screenRef = useRef(screen);
   const minDurationRef = useRef(minDuration);
   const maxEntriesRef = useRef(maxEntries);
+  const perfContext = usePerfContext();
 
   useEffect(() => {
     onLongTaskRef.current = onLongTask;
@@ -232,15 +234,19 @@ export function useLongTasks(options: UseLongTasksOptions = {}): UseLongTasksRet
     maxEntriesRef.current = maxEntries;
   }, [maxEntries, minDuration, onLongTask, screen]);
 
-  const handleEntry = useCallback((entry: LongTaskEntryLike) => {
-    if (entry.duration < minDurationRef.current) return;
-    if (!markEntryProcessed(entry)) return;
+  const handleEntry = useCallback(
+    (entry: LongTaskEntryLike) => {
+      if (entry.duration < minDurationRef.current) return;
+      if (!markEntryProcessed(entry)) return;
 
-    const metric = toLongTaskMetric(entry, resolveScreen(screenRef.current));
+      const metric = toLongTaskMetric(entry, resolveScreen(screenRef.current));
 
-    setEntries((current) => retainLatestEntries(current, metric, maxEntriesRef.current));
-    onLongTaskRef.current?.(metric);
-  }, []);
+      setEntries((current) => retainLatestEntries(current, metric, maxEntriesRef.current));
+      onLongTaskRef.current?.(metric);
+      perfContext?.reportMetric(metric.name, metric.duration, metric);
+    },
+    [perfContext],
+  );
 
   useEffect(() => {
     if (!enabled || !isSupported) return;

--- a/src/hooks/useLongTasks/useLongTasks.test.tsx
+++ b/src/hooks/useLongTasks/useLongTasks.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PerfProvider } from '../../components/PerfProvider';
 import { useLongTasks } from './index';
 
 type ObserverCallback = (
@@ -203,6 +204,23 @@ describe('useLongTasks', () => {
 
     expect(secondRender.result.current.entries).toEqual([]);
     expect(onLongTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports metrics to a wrapping PerfProvider', () => {
+    const onMetricsReport = vi.fn();
+    renderHook(() => useLongTasks(), {
+      wrapper: ({ children }) => (
+        <PerfProvider onMetricsReport={onMetricsReport}>{children}</PerfProvider>
+      ),
+    });
+
+    emitEntry({ name: 'self', duration: 200, startTime: 999 });
+
+    expect(onMetricsReport).toHaveBeenCalledWith(
+      'longtask',
+      200,
+      expect.objectContaining({ name: 'longtask', duration: 200 }),
+    );
   });
 
   it('does not subscribe when enabled=false', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,11 @@
+export { PerfProvider, usePerfContext } from './components/PerfProvider';
+export type {
+  PerfContextValue,
+  PerfMetricAttribution,
+  PerfMetricsReporter,
+  PerfProviderProps,
+} from './components/PerfProvider';
+
 export { useRenderTracker } from './hooks/useRenderTracker';
 export type { RenderInfo, UseRenderTrackerOptions } from './hooks/useRenderTracker';
 


### PR DESCRIPTION
## Summary
- Add `PerfProvider` (React Context) and `usePerfContext` as a centralized collector hub for performance metrics.
- Wire `useINP`, `useCLS`, and `useLongTasks` to bubble their metrics to `onMetricsReport` when a `PerfProvider` is present, with local-only fallback otherwise.
- Document integration examples for Sentry, Datadog RUM, and Google Analytics 4.

Closes #26

## Test plan
- [x] `npx vitest run` (190 tests passed)
- [x] `npx tsc --noEmit -p .`
- [x] `npx eslint` on changed files
- [x] `npm run build` (tsup build succeeds, types generated)