### PR TITLE
fix(ci): pin package dry-run to Node 26.x, fix docs type-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v7.0.0
-        if: matrix.node-version == '27.x'
+        if: matrix.node-version == '26.x'
         with:
           name: coverage
           path: coverage/
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload dist artifact
         uses: actions/upload-artifact@v7.0.0
-        if: matrix.node-version == '27.x'
+        if: matrix.node-version == '26.x'
         with:
           name: dist
           path: dist/
@@ -80,10 +80,10 @@ jobs:
         with:
           run_install: false
 
-      - name: Set up Node 27
+      - name: Set up Node 26
         uses: actions/setup-node@v6.3.0
         with:
-          node-version: 27.x
+          node-version: 26.x
           cache: pnpm
 
       - name: Install dependencies

--- a/tsconfig.docs.json
+++ b/tsconfig.docs.json
@@ -11,5 +11,13 @@
     "src/pages/**/*",
     "docs/**/*"
   ],
-  "exclude": ["node_modules", ".docusaurus", "docs-build", "build", "dist"]
+  "exclude": [
+    "node_modules",
+    ".docusaurus",
+    "docs-build",
+    "build",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ]
 }


### PR DESCRIPTION
## Summary
- `package-dry-run` job in ci.yml hardcoded `node-version: 27.x`, which does not exist yet, so CI failed outright on every push to main.
- Matrix upload conditions checked `matrix.node-version == '27.x'` too, but the matrix only runs 22.x/24.x/26.x, so coverage/dist artifacts were silently never uploaded.
- `tsconfig.docs.json` type-checked `*.test.tsx` files without jest-dom matcher types, breaking `docs:type-check` after PerfProvider's test file was added in #68.

## Test plan
- [x] `pnpm docs:type-check` passes
- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes