### PR TITLE
Chore: standardize production tree-shaking and process.env.NODE_ENV gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v7.0.0
-        if: matrix.node-version == '27.x'
+        if: matrix.node-version == '26.x'
         with:
           name: coverage
           path: coverage/
@@ -58,9 +58,12 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Check bundle size (production tree-shaking)
+        run: pnpm size
+
       - name: Upload dist artifact
         uses: actions/upload-artifact@v7.0.0
-        if: matrix.node-version == '27.x'
+        if: matrix.node-version == '26.x'
         with:
           name: dist
           path: dist/
@@ -80,10 +83,10 @@ jobs:
         with:
           run_install: false
 
-      - name: Set up Node 27
+      - name: Set up Node 26
         uses: actions/setup-node@v6.3.0
         with:
-          node-version: 27.x
+          node-version: 26.x
           cache: pnpm
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "lint:fix": "eslint src/index.ts src/hooks src/test-setup.ts --fix",
     "format": "prettier --write \"{src,docs,examples}/**/*.{ts,tsx,js,jsx,mjs,cjs,mts,cts,md,mdx}\" \"*.{ts,js,mjs,json,md}\"",
     "format:check": "prettier --check \"{src,docs,examples}/**/*.{ts,tsx,js,jsx,mjs,cjs,mts,cts,md,mdx}\" \"*.{ts,js,mjs,json,md}\"",
-    "ci": "pnpm type-check && pnpm lint && pnpm format:check && pnpm test:run && pnpm build",
+    "ci": "pnpm type-check && pnpm lint && pnpm format:check && pnpm test:run && pnpm build && pnpm size",
+    "size": "size-limit",
     "prepublishOnly": "pnpm run ci",
     "release:patch": "pnpm version patch && pnpm publish --access public",
     "release:minor": "pnpm version minor && pnpm publish --access public",
@@ -75,6 +76,7 @@
     "@eslint/js": "^10.0.1",
     "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
     "@mdx-js/react": "^3.1.1",
+    "@size-limit/preset-small-lib": "^13.0.3",
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^26.2.0",
@@ -88,6 +90,7 @@
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
+    "size-limit": "^13.0.3",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.67.0",
@@ -129,5 +132,37 @@
       "last 3 firefox version",
       "last 5 safari version"
     ]
-  }
+  },
+  "size-limit": [
+    {
+      "name": "ESM - single hook (production tree-shaking)",
+      "path": "dist/index.mjs",
+      "import": "{ useRenderCount }",
+      "limit": "2 KB",
+      "ignore": [
+        "react",
+        "react-dom"
+      ]
+    },
+    {
+      "name": "ESM - full library (production build)",
+      "path": "dist/index.mjs",
+      "import": "*",
+      "limit": "11 KB",
+      "ignore": [
+        "react",
+        "react-dom"
+      ]
+    },
+    {
+      "name": "CJS - full library (production build)",
+      "path": "dist/index.js",
+      "import": "*",
+      "limit": "11 KB",
+      "ignore": [
+        "react",
+        "react-dom"
+      ]
+    }
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@mdx-js/react':
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.18)(react@19.2.8)
+      '@size-limit/preset-small-lib':
+        specifier: ^13.0.3
+        version: 13.0.3(size-limit@13.0.3)
       '@testing-library/jest-dom':
         specifier: ^7.0.1
         version: 7.0.1(@testing-library/dom@10.4.1)(vitest@4.1.10)
@@ -80,6 +83,9 @@ importers:
       react-dom:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
+      size-limit:
+        specifier: ^13.0.3
+        version: 13.0.3
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.16.0)(jiti@1.21.7)(postcss@8.5.26)(typescript@5.9.3)
@@ -2194,6 +2200,23 @@ packages:
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
     engines: {node: '>=14.16'}
 
+  '@size-limit/esbuild@13.0.3':
+    resolution: {integrity: sha512-g24wsTxM3N/SaGv1MiiDjTShNrIna1WCNJ7NXMrlsWBHWv1OL0nCyllR1bDDHf+gV41lF7QxX7vknswoOr71DQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      size-limit: 13.0.3
+
+  '@size-limit/file@13.0.3':
+    resolution: {integrity: sha512-PWTITIXH5p9aGIf6qq2Fruihn/b9nBQyfkyoAyb6DzFJgS1Ek9MSPJYKxKFLO8jdo0aqSgBPd3sevbS6PyBiJw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      size-limit: 13.0.3
+
+  '@size-limit/preset-small-lib@13.0.3':
+    resolution: {integrity: sha512-rqKn1+JkVF5ckZRmcxeQPZ8g0e9Fqddh6bjmDotijXJtN40KJQ+5TG6pTiYq3RaA4nkuEkixHULpDBGcgAARAg==}
+    peerDependencies:
+      size-limit: 13.0.3
+
   '@slorber/react-helmet-async@1.3.0':
     resolution: {integrity: sha512-e9/OK8VhwUSc67diWI8Rb3I0YgI9/SBQtnhe9aEuK6MhZm7ntZZimXgwXnd8W96YTmSOb9M4d8LwhRZyhWr/1A==}
     peerDependencies:
@@ -3034,6 +3057,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: 0.28.1
+
+  bytes-iec@3.1.1:
+    resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
+    engines: {node: '>= 0.8'}
 
   bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
@@ -4952,6 +4979,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanospinner@1.2.2:
+    resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -6038,6 +6068,11 @@ packages:
   sitemap@7.1.3:
     resolution: {integrity: sha512-tAjEd+wt/YwnEbfNB2ht51ybBJxbEWwe5ki/Z//Wh0rpBFTCUSj46GnxUKEWzhfuJTsee8x3lybHxFgUMig2hw==}
     engines: {node: '>=12.0.0', npm: '>=5.6.0'}
+    hasBin: true
+
+  size-limit@13.0.3:
+    resolution: {integrity: sha512-KVb2aNEU49BwTR21SVjD+2QHP9gBV/nWsTHzNB/heRwXtHyA7lLQiDZDQ1TiNh/B/TZXKAZrHYyTt+cvBUrzYw==}
+    engines: {node: ^22.18.0 || ^24.0.0 || >=26.0.0}
     hasBin: true
 
   skin-tone@2.0.0:
@@ -9896,6 +9931,22 @@ snapshots:
 
   '@sindresorhus/is@5.6.0': {}
 
+  '@size-limit/esbuild@13.0.3(size-limit@13.0.3)':
+    dependencies:
+      esbuild: 0.28.1
+      nanoid: 3.3.18
+      size-limit: 13.0.3
+
+  '@size-limit/file@13.0.3(size-limit@13.0.3)':
+    dependencies:
+      size-limit: 13.0.3
+
+  '@size-limit/preset-small-lib@13.0.3(size-limit@13.0.3)':
+    dependencies:
+      '@size-limit/esbuild': 13.0.3(size-limit@13.0.3)
+      '@size-limit/file': 13.0.3(size-limit@13.0.3)
+      size-limit: 13.0.3
+
   '@slorber/react-helmet-async@1.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -10831,6 +10882,8 @@ snapshots:
     dependencies:
       esbuild: 0.28.1
       load-tsconfig: 0.2.5
+
+  bytes-iec@3.1.1: {}
 
   bytes@3.0.0: {}
 
@@ -13128,6 +13181,10 @@ snapshots:
 
   nanoid@3.3.18: {}
 
+  nanospinner@1.2.2:
+    dependencies:
+      picocolors: 1.1.1
+
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
@@ -14401,6 +14458,12 @@ snapshots:
       '@types/sax': 1.2.7
       arg: 5.0.2
       sax: 1.6.1
+
+  size-limit@13.0.3:
+    dependencies:
+      bytes-iec: 3.1.1
+      lilconfig: 3.1.3
+      nanospinner: 1.2.2
 
   skin-tone@2.0.0:
     dependencies:

--- a/src/hooks/useMemoProfiling/index.ts
+++ b/src/hooks/useMemoProfiling/index.ts
@@ -27,8 +27,6 @@ interface MemoSnapshot<T> {
 const DEFAULT_LABEL = 'default';
 const statsStore = new Map<string, MutableMemoProfilingStats>();
 
-const isProfilingEnabled = (): boolean => process.env.NODE_ENV !== 'production';
-
 const getNow = (): number => {
   if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
     return performance.now();
@@ -80,7 +78,7 @@ const getOrCreateStats = (label: string): MutableMemoProfilingStats => {
 export function getStats(label?: string): MemoProfilingStats {
   const resolvedLabel = normalizeLabel(label);
 
-  if (!isProfilingEnabled()) {
+  if (process.env.NODE_ENV === 'production') {
     return toPublicStats(resolvedLabel);
   }
 
@@ -93,7 +91,7 @@ export function getStats(label?: string): MemoProfilingStats {
  */
 export function useMemoProfiling<T>(factory: () => T, deps: DependencyList, label?: string): T {
   const resolvedLabel = normalizeLabel(label);
-  const profilingEnabled = isProfilingEnabled();
+  const profilingEnabled = process.env.NODE_ENV !== 'production';
 
   // Intentionally mirror useMemo semantics by trusting caller-provided deps.
   /* eslint-disable react-hooks/use-memo, react-hooks/exhaustive-deps */

--- a/tsconfig.docs.json
+++ b/tsconfig.docs.json
@@ -11,5 +11,13 @@
     "src/pages/**/*",
     "docs/**/*"
   ],
-  "exclude": ["node_modules", ".docusaurus", "docs-build", "build", "dist"]
+  "exclude": [
+    "node_modules",
+    ".docusaurus",
+    "docs-build",
+    "build",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ]
 }


### PR DESCRIPTION
Closes #27.

## Summary
- Audited every hook's `console.*`/deep-equality/profiling code paths. Most hooks (`useRenderTracker`, `useRenderCount`, `useRenderBudget`, `useWhyDidYouUpdate`, `useAllocationTracker`, `useComponentLifecycle`) already used the standard `enabled = process.env.NODE_ENV !== 'production'` pattern, which minifiers can fold and dead-code-eliminate when the flag isn't overridden.
- `useMemoProfiling` was the outlier: it computed the flag via a shared `isProfilingEnabled()` top-level function instead of an inline literal check. A plain function call is less reliably inlined/folded by minifiers than the same check written inline in each scope, so it's now standardized to match the rest of the hooks.
- `usePerformanceMark`'s `console.error` and `useWebVitals`'s `console.warn` were left as-is — those report genuine runtime/config errors (bad Performance API usage, missing `web-vitals` peer dep), not dev-only debugging noise, so gating them behind `NODE_ENV` would hide real failures from production users.
- Added `size-limit` (`@size-limit/preset-small-lib`) to actually verify the production tree-shaking claim instead of just asserting it: it builds each entry through its own production-mode bundler and reports the real minified+brotli size.
  - A single-hook ESM import (`{ useRenderCount }`) → **256 B**, confirming per-hook tree-shaking works and dev-only code doesn't leak in.
  - Full ESM and CJS builds → **~10.5-10.7 KB**, under an 11 KB budget.
  - Wired into `pnpm ci` (`pnpm size`) and into the CI workflow's build step.
- Also fixes a couple of preexisting CI bugs blocking `main` so this branch's own checks are green: `package-dry-run` was pinned to a nonexistent `node-version: 27.x` (and the matrix upload conditions referenced the same nonexistent version), and `tsconfig.docs.json` type-checked `*.test.tsx` files without jest-dom matcher types. (Also filed standalone as #69.)

## Test plan
- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test:run` (196 tests)
- [x] `pnpm build`
- [x] `pnpm size` (size-limit passes for ESM single-hook, ESM full, CJS full)